### PR TITLE
Add Lottie icons with fallbacks and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# Sostenivilitat_v1
+# Sostenibilidad 2030 — Guía de edición
+
+Este repositorio contiene una demo educativa de los cuatro grandes retos de sostenibilidad. A continuación encontrarás todo lo necesario para personalizar datos, animaciones, estilos y recursos multimedia sin perder el enfoque en accesibilidad y rendimiento.
+
+## Estructura del proyecto
+
+- `index.html`: página principal con el hero, los cuatro retos, el mapa y el JSON embebido con los datos de los retos.
+- `retos/`: casos detallados para cada reto (HTML estático).
+- `styles/main.css`: hoja de estilos global con tokens y componentes.
+- `scripts/animations.js`, `scripts/map.js`, `scripts/app.js`: lógica de animaciones, mapa interactivo y comportamiento general.
+- `assets/lottie/`: configuraciones JSON que apuntan a animaciones públicas en LottieFiles (`planeta.json`, `gota.json`, `hoja.json`).
+- `assets/img/`: referencias JSON a imágenes dinámicas de [Unsplash Source](https://source.unsplash.com) (`planeta.json`, `gota.json`, `hoja.json`).
+
+## Editar el JSON embebido de retos
+
+El listado mostrado en el mapa y en el panel lateral se alimenta del bloque `<script id="data-retos" type="application/json">` presente en `index.html`.
+
+1. Localiza el bloque dentro de la sección `#mapa-global`.
+2. Cada reto incluye las claves `id`, `nombre`, `resumen`, `coordenadas`, `imagen`, `imagenAlt`, `ruta` y `emoji`.
+3. Para añadir un nuevo reto duplica uno existente y ajusta:
+   - `id`: identificador único en minúsculas y sin espacios.
+   - `coordenadas`: array `[latitud, longitud]` en formato decimal.
+   - `imagen`: URL de Unsplash Source (consulta el apartado **Imágenes** más abajo).
+   - `imagenAlt`: descripción corta y objetiva de la imagen (se usa en cards, popups y panel lateral).
+   - `ruta`: enlace relativo al detalle en `/retos/`.
+4. Guarda el archivo. Al recargar la página el mapa y las tarjetas se actualizarán automáticamente.
+
+> Consejo: mantén los textos concisos (máximo 140 caracteres) para evitar desbordes en el panel.
+
+## Actualizar textos e imágenes
+
+- **Textos principales:** edítalos directamente en `index.html` o en los archivos específicos dentro de `retos/`. Los elementos con la clase `split-ready` están segmentados palabra a palabra para animaciones; mantén las etiquetas `<span>` al editar títulos.
+- **Imágenes del mapa y las tarjetas:** utiliza URLs de Unsplash Source para evitar almacenar binarios. Puedes documentar la URL correspondiente en `assets/img/*.json` y reutilizarla en el JSON de retos o en cualquier `<img>`. Ejemplo: `https://source.unsplash.com/collection/2290905/800x600?solar`.
+- **Fallbacks de iconos:** cada figura con clase `.reto-icon` incluye una imagen de respaldo. Asegúrate de proporcionar un texto alternativo descriptivo.
+
+## Modificar variables CSS
+
+`styles/main.css` centraliza los tokens en la sección `:root` (colores, tipografías, radios, sombras y espaciados). Para modificar el aspecto global:
+
+1. Ajusta los valores en `:root` para el tema claro y en `[data-theme="dark"]` para el modo oscuro.
+2. Al añadir nuevos tokens sigue la convención `--nombre-kebab-case`.
+3. Comprueba contraste mínimo AA (4.5:1) al cambiar colores de texto o fondo.
+
+## Reemplazar iconos Lottie
+
+Las animaciones se cargan usando los JSON de `assets/lottie/` junto con la librería Lottie-web.
+
+1. Sustituye el contenido del archivo correspondiente (`planeta.json`, `gota.json` o `hoja.json`) indicando la nueva URL pública (`src`) y, opcionalmente, `name`, `description`, `loop`, `autoplay` y `renderer`.
+2. Si necesitas un nuevo icono, crea un archivo adicional dentro de `assets/lottie/` y referencia su ruta relativa en el atributo `data-lottie-config` de la figura deseada.
+3. El script detecta automáticamente la ausencia de Lottie y mantiene visible el fallback (`data-fallback-image`). No elimines esa imagen para conservar la accesibilidad.
+
+## Añadir fuentes bibliográficas y recursos
+
+- Utiliza la sección de créditos del `footer` o crea un `<section>` específico antes del pie con una lista `<ol>` o `<ul>`.
+- Incluye autor, título, año y URL. Ejemplo:
+  ```html
+  <li>
+    "Plan Nacional Integrado de Energía y Clima 2021-2030" (2023). Ministerio para la Transición Ecológica. Disponible en ...
+  </li>
+  ```
+- Para citas internas añade enlaces con `rel="noopener"` y `target="_blank"` cuando se trate de recursos externos.
+
+## Optimizar rendimiento y accesibilidad
+
+- **Imágenes:** fija dimensiones en la URL de Unsplash Source (`/800x600`) y añade `loading="lazy"` y `decoding="async"` (ya configurado en los scripts). Considera sustituirlas por versiones optimizadas alojadas en un CDN propio si el proyecto pasa a producción.
+- **Vídeos:** proporciona un `poster` ligero y comprime el archivo (`ffmpeg -crf 23 -preset slow`).
+- **Preloads y preconnect:** la cabecera ya incluye `preconnect` para Google Fonts. Añade `<link rel="preload">` para recursos críticos si incorporas nuevas fuentes o scripts pesados.
+- **JavaScript:** evita bloquear el hilo principal. Usa `defer` o `type="module"` y elimina dependencias no utilizadas.
+- **Accesibilidad:** mantén textos alternativos, roles descriptivos y foco visible. Revisa contrastes con herramientas como Lighthouse o axe.
+- **Preferencias del usuario:** el código respeta `prefers-reduced-motion`. Evita animaciones bruscas en nuevos componentes.
+
+## Ejecutar la demo localmente
+
+1. Clona o descarga el repositorio.
+2. Abre `index.html` en tu navegador preferido (doble clic o arrastrar al navegador).
+3. Para asegurar la carga de los JSON locales en algunos navegadores, se recomienda usar un servidor estático sencillo (`npx serve`, `python -m http.server`, etc.), aunque el sitio funciona en modo solo lectura con apertura directa.
+
+## Buenas prácticas al agregar nuevo contenido
+
+- Utiliza jerarquías semánticas (`<h2>`, `<h3>`, listas, `<figure>` con `<figcaption>` cuando corresponda).
+- Añade `alt` descriptivos, evita textos como “imagen 1”.
+- Respeta el orden lógico de tabulación y verifica que los controles sean accesibles con teclado.
+- Mantén el peso de imágenes individuales por debajo de 250 KB cuando sea posible (usa compresión y formatos modernos como AVIF/WebP si cuentas con un servidor).
+- Prefiere animaciones vectoriales y evita autoplay de audio. Si integras nuevos Lottie, verifica que dispongan de fallback.
+- Documenta en este README cualquier cambio estructural relevante para que el equipo lo pueda seguir.
+
+---
+
+¿Dudas o mejoras? Puedes abrir un issue o documentar propuestas directamente en esta guía.

--- a/assets/img/gota.json
+++ b/assets/img/gota.json
@@ -1,0 +1,4 @@
+{
+  "src": "https://source.unsplash.com/collection/827743/480x480?water",
+  "alt": "Macro de una gota de agua cristalina cayendo"
+}

--- a/assets/img/hoja.json
+++ b/assets/img/hoja.json
@@ -1,0 +1,4 @@
+{
+  "src": "https://source.unsplash.com/collection/888146/480x480?leaf",
+  "alt": "Detalle de una hoja verde con gotas de rocío"
+}

--- a/assets/img/planeta.json
+++ b/assets/img/planeta.json
@@ -1,0 +1,4 @@
+{
+  "src": "https://source.unsplash.com/collection/190727/480x480?earth",
+  "alt": "Fotografía aérea del planeta Tierra iluminado por el sol"
+}

--- a/assets/lottie/gota.json
+++ b/assets/lottie/gota.json
@@ -1,0 +1,8 @@
+{
+  "name": "Gota de agua",
+  "description": "Animación de una gota de agua que representa la gestión hídrica.",
+  "src": "https://assets3.lottiefiles.com/packages/lf20_sgn7c9.json",
+  "renderer": "svg",
+  "loop": true,
+  "autoplay": true
+}

--- a/assets/lottie/hoja.json
+++ b/assets/lottie/hoja.json
@@ -1,0 +1,8 @@
+{
+  "name": "Hoja flotante",
+  "description": "Animación ligera de una hoja verde que simboliza regeneración y biodiversidad.",
+  "src": "https://assets10.lottiefiles.com/packages/lf20_jcikwtux.json",
+  "renderer": "svg",
+  "loop": true,
+  "autoplay": true
+}

--- a/assets/lottie/planeta.json
+++ b/assets/lottie/planeta.json
@@ -1,0 +1,8 @@
+{
+  "name": "Planeta girando",
+  "description": "Animación de un planeta con órbitas que refuerza el enfoque global del proyecto.",
+  "src": "https://assets9.lottiefiles.com/packages/lf20_t24tpvcu.json",
+  "renderer": "svg",
+  "loop": true,
+  "autoplay": true
+}

--- a/index.html
+++ b/index.html
@@ -120,7 +120,14 @@
     <main id="contenido-principal" data-barba="container" data-barba-namespace="home">
       <section id="hero" aria-labelledby="hero-heading">
         <div class="hero-media" aria-hidden="true">
-          <video src="/media/planeta.mp4" autoplay muted loop playsinline poster="/media/planeta.jpg"></video>
+          <video
+            src="/media/planeta.mp4"
+            autoplay
+            muted
+            loop
+            playsinline
+            poster="https://source.unsplash.com/collection/190727/1280x720?earth"
+          ></video>
         </div>
         <div class="hero-overlay" aria-hidden="true"></div>
         <div class="parallax-layer" data-depth="0.2" aria-hidden="true">
@@ -167,6 +174,21 @@
           </svg>
         </div>
         <article class="reto-content" aria-labelledby="reto-energia-titulo">
+          <figure class="reto-icon" data-state="fallback">
+            <div
+              class="reto-icon__animation"
+              data-lottie-config="assets/lottie/planeta.json"
+              data-fallback-config="assets/img/planeta.json"
+              aria-hidden="true"
+            ></div>
+            <img
+              class="reto-icon__fallback"
+              data-fallback-image
+              src="https://source.unsplash.com/collection/190727/320x320?planet"
+              alt="Ilustración del planeta Tierra rodeado por órbitas luminosas"
+              loading="lazy"
+            />
+          </figure>
           <h2 id="reto-energia-titulo" class="reto-title split-ready">
             <span>Reto</span> <span>1:</span> <span>Transición</span> <span>energética</span>
           </h2>
@@ -201,6 +223,21 @@
           </svg>
         </div>
         <article class="reto-content" aria-labelledby="reto-agua-titulo">
+          <figure class="reto-icon" data-state="fallback">
+            <div
+              class="reto-icon__animation"
+              data-lottie-config="assets/lottie/gota.json"
+              data-fallback-config="assets/img/gota.json"
+              aria-hidden="true"
+            ></div>
+            <img
+              class="reto-icon__fallback"
+              data-fallback-image
+              src="https://source.unsplash.com/collection/827743/320x320?water"
+              alt="Ilustración de una gota de agua suspendida sobre un fondo azul"
+              loading="lazy"
+            />
+          </figure>
           <h2 id="reto-agua-titulo" class="reto-title split-ready">
             <span>Reto</span> <span>2:</span> <span>Gestión</span> <span>del</span> <span>agua</span>
           </h2>
@@ -235,6 +272,21 @@
           </svg>
         </div>
         <article class="reto-content" aria-labelledby="reto-biodiversidad-titulo">
+          <figure class="reto-icon" data-state="fallback">
+            <div
+              class="reto-icon__animation"
+              data-lottie-config="assets/lottie/hoja.json"
+              data-fallback-config="assets/img/hoja.json"
+              aria-hidden="true"
+            ></div>
+            <img
+              class="reto-icon__fallback"
+              data-fallback-image
+              src="https://source.unsplash.com/collection/888146/320x320?leaf"
+              alt="Ilustración de una hoja verde con gotas de rocío"
+              loading="lazy"
+            />
+          </figure>
           <h2 id="reto-biodiversidad-titulo" class="reto-title split-ready">
             <span>Reto</span> <span>3:</span> <span>Regenerar</span> <span>la</span> <span>biodiversidad</span>
           </h2>
@@ -300,7 +352,12 @@
           <div class="map-details">
             <h3 data-map-title>Selecciona un reto</h3>
             <p data-map-summary>Los datos aparecerán aquí cuando interactúes con el mapa.</p>
-            <img data-map-image alt="" hidden loading="lazy" />
+            <img
+              data-map-image
+              alt="Vista ilustrativa del reto seleccionado en el mapa global"
+              hidden
+              loading="lazy"
+            />
             <a data-map-link href="#" target="_blank" rel="noopener" hidden>Explorar recurso</a>
           </div>
           <p class="map-attribution">
@@ -316,7 +373,8 @@
                 "nombre": "Transición energética",
                 "resumen": "Parques solares comunitarios en Atacama que abastecen a 1,2 millones de hogares.",
                 "coordenadas": [-24.385, -69.332],
-                "imagen": "https://images.unsplash.com/photo-1509395062183-67c5ad6faff9",
+                "imagen": "https://source.unsplash.com/collection/2290905/800x600?solar",
+                "imagenAlt": "Vista aérea de paneles solares en el desierto de Atacama",
                 "ruta": "/retos/reto-clima.html",
                 "emoji": "⚡"
               },
@@ -325,7 +383,8 @@
                 "nombre": "Gestión del agua",
                 "resumen": "Desalinización con energías renovables para comunidades costeras en Marruecos.",
                 "coordenadas": [31.7917, -7.0926],
-                "imagen": "https://images.unsplash.com/photo-1501612780327-45045538702b",
+                "imagen": "https://source.unsplash.com/collection/483251/800x600?desalination",
+                "imagenAlt": "Tuberías y depósitos de una planta de desalinización junto al mar",
                 "ruta": "/retos/reto-agua.html",
                 "emoji": "💧"
               },
@@ -334,7 +393,8 @@
                 "nombre": "Regenerar la biodiversidad",
                 "resumen": "Corredores biológicos amazónicos que conectan 12 reservas indígenas.",
                 "coordenadas": [-3.4653, -62.2159],
-                "imagen": "https://images.unsplash.com/photo-1469474968028-56623f02e42e",
+                "imagen": "https://source.unsplash.com/collection/484351/800x600?rainforest",
+                "imagenAlt": "Selva amazónica cubierta de niebla al amanecer",
                 "ruta": "/retos/reto-biodiversidad.html",
                 "emoji": "🌱"
               },
@@ -343,7 +403,8 @@
                 "nombre": "Ciudades circulares",
                 "resumen": "Red de movilidad eléctrica y reciclaje modular en Helsinki.",
                 "coordenadas": [60.1699, 24.9384],
-                "imagen": "https://images.unsplash.com/photo-1504384308090-c894fdcc538d",
+                "imagen": "https://source.unsplash.com/collection/483251/800x600?smart-city",
+                "imagenAlt": "Tranvía eléctrico circulando por una avenida moderna de Helsinki",
                 "ruta": "/retos/reto-aire.html",
                 "emoji": "🏙️"
               }

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -225,9 +225,10 @@
       if (reto.imagen) {
         const picture = document.createElement('img');
         picture.className = 'reto-card__image';
-        picture.src = `${reto.imagen}?auto=format&fit=crop&w=480&q=80`;
-        picture.alt = '';
+        picture.src = reto.imagen;
+        picture.alt = reto.imagenAlt || `Vista representativa del reto ${reto.nombre}`;
         picture.loading = 'lazy';
+        picture.decoding = 'async';
         card.appendChild(picture);
       }
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -61,10 +61,12 @@
     if (image) {
       if (reto && reto.imagen) {
         image.src = reto.imagen;
+        image.alt = reto.imagenAlt || `Vista representativa del reto ${reto.nombre}`;
         image.hidden = false;
       } else {
         image.hidden = true;
         image.removeAttribute('src');
+        image.alt = 'Vista ilustrativa del reto seleccionado en el mapa global';
       }
     }
 
@@ -97,8 +99,9 @@
   function renderPopupContent(reto) {
     const escapedName = reto.nombre;
     const escapedSummary = reto.resumen;
+    const imageAlt = reto.imagenAlt || `Vista representativa del reto ${reto.nombre}`;
     const imageHtml = reto.imagen
-      ? `<img src="${reto.imagen}" alt="" loading="lazy" />`
+      ? `<img src="${reto.imagen}" alt="${imageAlt}" loading="lazy" decoding="async" />`
       : '';
 
     const buttonHtml = reto.ruta

--- a/styles/main.css
+++ b/styles/main.css
@@ -581,6 +581,46 @@ nav {
   max-width: 960px;
 }
 
+.reto-icon {
+  display: grid;
+  place-items: center;
+  width: clamp(90px, 11vw, 150px);
+  aspect-ratio: 1 / 1;
+  margin: 0;
+  justify-self: start;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 28%, transparent),
+    0 18px 35px rgba(15, 23, 42, 0.28);
+  overflow: hidden;
+}
+
+.reto-icon__animation {
+  width: 72%;
+  height: 72%;
+}
+
+.reto-icon__fallback {
+  width: 72%;
+  height: 72%;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.25);
+  transition: opacity var(--transition-base);
+}
+
+.reto-icon__fallback[hidden] {
+  display: none;
+}
+
+.reto-icon[data-state="fallback"] .reto-icon__fallback {
+  opacity: 1;
+}
+
+.reto-icon[data-state="animated"] .reto-icon__fallback {
+  opacity: 0;
+}
+
 .reto-title {
   font-size: clamp(2rem, 4vw, 2.9rem);
   color: var(--color-text);


### PR DESCRIPTION
## Summary
- add configuration files under assets/ for Lottie icons and Unsplash Source image references
- integrate animated icons with graceful fallbacks in the reto sections and improve accessibility metadata for map content
- expand the README with instructions for managing retos JSON, styling, media, bibliographic sources, and performance practices

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6d6e6ab6883299774489a31b36dcd