### PR TITLE
Add root redirect to full docs site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sostenibilidad 2030</title>
+    <meta http-equiv="refresh" content="0; url=docs/" />
+    <link rel="canonical" href="docs/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        display: grid;
+        place-items: center;
+        height: 100vh;
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0c1c26;
+        color: #f3f9ff;
+        text-align: center;
+        padding: 1.5rem;
+      }
+      a {
+        color: inherit;
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Redirigiendo a la demo interactiva…</h1>
+      <p>
+        Si no eres redirigido automáticamente, visita la
+        <a href="docs/">versión completa del proyecto</a>.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a root-level landing page that redirects to the interactive demo under docs/
- include a fallback link and simple styling so the redirect page is still usable without auto-refresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6f62195a08329aca6e83f815b9d08