### PR TITLE
Fix root redirect to docs site

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Sostenibilidad 2030</title>
-    <meta http-equiv="refresh" content="0; url=docs/" />
-    <link rel="canonical" href="docs/" />
+    <meta http-equiv="refresh" content="0; url=./docs/" />
+    <link rel="canonical" href="./docs/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       body {
@@ -28,9 +28,18 @@
     <main>
       <h1>Redirigiendo a la demo interactiva…</h1>
       <p>
-        Si no eres redirigido automáticamente, visita la
-        <a href="docs/">versión completa del proyecto</a>.
+        Si no eres redirigido automáticamente, serás llevado a la
+        <a href="./docs/">versión completa del proyecto</a>.
       </p>
+      <script>
+        (function () {
+          var currentPath = window.location.pathname.replace(/\/[^/]*$/, "/");
+          var target = currentPath + "docs/";
+          if (!window.location.pathname.endsWith("/docs/")) {
+            window.location.replace(target);
+          }
+        })();
+      </script>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update the root index redirect to preserve the repository path
- add a JavaScript fallback to send visitors to the docs site
- adjust link and messaging to point to the full experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6f80eb3788329a8f1ebde5c685391