### PR TITLE
Limit map bounds and refine scroll behavior

### DIFF
--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -12,6 +12,7 @@
     retosData: [],
     overlay: null,
     navLinks: [],
+    initialScrollBehavior: null,
   };
 
   function addCleanup(fn) {
@@ -39,9 +40,22 @@
     }
 
     if (prefersReducedMotion.matches || typeof window.Lenis !== 'function') {
+      if (state.initialScrollBehavior !== null) {
+        if (state.initialScrollBehavior === '') {
+          document.documentElement.style.removeProperty('scroll-behavior');
+        } else {
+          document.documentElement.style.scrollBehavior = state.initialScrollBehavior;
+        }
+        state.initialScrollBehavior = null;
+      }
       state.lenis = null;
       return;
     }
+
+    if (state.initialScrollBehavior === null) {
+      state.initialScrollBehavior = document.documentElement.style.scrollBehavior || '';
+    }
+    document.documentElement.style.scrollBehavior = 'auto';
 
     const easing = (t) => (t === 1 ? 1 : 1 - Math.pow(2, -1.35 * t));
     const lenis = new window.Lenis({
@@ -83,6 +97,12 @@
       lenis.destroy();
       state.lenis = null;
       state.lenisCleanup = null;
+      if (state.initialScrollBehavior === '') {
+        document.documentElement.style.removeProperty('scroll-behavior');
+      } else {
+        document.documentElement.style.scrollBehavior = state.initialScrollBehavior || '';
+      }
+      state.initialScrollBehavior = null;
     };
     state.cleanupFns.push(state.lenisCleanup);
   }

--- a/docs/scripts/map.js
+++ b/docs/scripts/map.js
@@ -145,12 +145,24 @@
     const map = window.L.map(container, {
       zoomControl: true,
       preferCanvas: false,
+      worldCopyJump: false,
+      maxBoundsViscosity: 1,
     });
 
-    window.L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 19,
-      attribution: '&copy; OpenStreetMap contribuidores',
-    }).addTo(map);
+    const worldBounds = window.L.latLngBounds(
+      window.L.latLng(-90, -180),
+      window.L.latLng(90, 180)
+    );
+    map.setMaxBounds(worldBounds);
+
+    window.L
+      .tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; OpenStreetMap contribuidores',
+        noWrap: true,
+        bounds: worldBounds,
+      })
+      .addTo(map);
 
     fitMapToRetos(map, state.retos);
 
@@ -220,14 +232,26 @@
         zoomControl: true,
         scrollWheelZoom: false,
         dragging: true,
+        worldCopyJump: false,
+        maxBoundsViscosity: 1,
       });
+
+      const worldBounds = window.L.latLngBounds(
+        window.L.latLng(-90, -180),
+        window.L.latLng(90, 180)
+      );
+      map.setMaxBounds(worldBounds);
 
       map.setView([lat, lng], Number.isFinite(zoom) ? zoom : 10);
 
-      window.L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        maxZoom: 19,
-        attribution: '&copy; OpenStreetMap contribuidores',
-      }).addTo(map);
+      window.L
+        .tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 19,
+          attribution: '&copy; OpenStreetMap contribuidores',
+          noWrap: true,
+          bounds: worldBounds,
+        })
+        .addTo(map);
 
       const marker = window.L.marker([lat, lng], {
         icon: window.L.divIcon({

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -147,7 +147,7 @@ body {
   background-color: var(--color-surface);
   color: var(--color-text);
   font-family: var(--font-body);
-  scroll-snap-type: y mandatory;
+  scroll-snap-type: y proximity;
   overflow-x: hidden;
   transition: background-color var(--transition-long), color var(--transition-long);
 }
@@ -838,6 +838,7 @@ footer small {
 
   body {
     scroll-behavior: auto;
+    scroll-snap-type: none;
   }
 
   .parallax-layer,


### PR DESCRIPTION
## Summary
- prevent the Leaflet maps from wrapping endlessly by enforcing world bounds and disabling tile wrapping
- relax global scroll snapping and restore native scroll behavior when Lenis is active for smoother page scrolling
- ensure reduced-motion users avoid scroll snapping altogether

## Testing
- Manual testing via `python3 -m http.server 8000` and Playwright screenshot capture

------
https://chatgpt.com/codex/tasks/task_b_68d6fd0816c48329a353640d3fd59771