### PR TITLE
Disable smooth scrolling delay

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -139,15 +139,10 @@ a:focus-visible {
   --color-card-gradient-bottom: rgba(45, 212, 191, 0.22);
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 body {
   background-color: var(--color-surface);
   color: var(--color-text);
   font-family: var(--font-body);
-  scroll-snap-type: y proximity;
   overflow-x: hidden;
   transition: background-color var(--transition-long), color var(--transition-long);
 }


### PR DESCRIPTION
## Summary
- remove the global smooth-scroll behavior from the base stylesheet
- disable body-level scroll snapping so wheel/touch scrolling responds instantly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d7003b77c08329bf3074f4fcd4c01f