### PR TITLE
Improve global map sizing and rendering

### DIFF
--- a/docs/scripts/map.js
+++ b/docs/scripts/map.js
@@ -204,6 +204,8 @@
     window.addEventListener('resize', resize);
     registerCleanup(() => window.removeEventListener('resize', resize));
 
+    window.requestAnimationFrame(() => map.invalidateSize());
+
     state.globalMap = map;
     state.maps.set(container, map);
     updateDetails(null);

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -663,13 +663,15 @@ nav {
   border-radius: var(--radius-lg);
   overflow: hidden;
   border: 1px solid var(--color-border);
-  min-height: 60vh;
+  min-height: clamp(320px, 55vh, 560px);
   box-shadow: var(--shadow-sm);
+  display: flex;
 }
 
 #mapa-global #map {
   width: 100%;
   height: 100%;
+  flex: 1;
 }
 
 .map-panel {


### PR DESCRIPTION
## Summary
- reduce the map container height to a more balanced clamp range while keeping full width coverage
- ensure the Leaflet map invalidates its size on the next frame so tiles fill the available space

## Testing
- manual verification

------
https://chatgpt.com/codex/tasks/task_b_68d701e9b7f88329be2caeb5302bdb5d