### PR TITLE
Ajusta presentación del mapa global y marcadores

### DIFF
--- a/docs/scripts/map.js
+++ b/docs/scripts/map.js
@@ -90,9 +90,9 @@
     return window.L.divIcon({
       className: 'map-marker',
       html: `<span aria-hidden="true">${markerEmoji}</span>`,
-      iconSize: [32, 32],
-      iconAnchor: [16, 30],
-      popupAnchor: [0, -24],
+      iconSize: [48, 48],
+      iconAnchor: [24, 42],
+      popupAnchor: [0, -32],
     });
   }
 
@@ -147,6 +147,7 @@
       preferCanvas: false,
       worldCopyJump: false,
       maxBoundsViscosity: 1,
+      minZoom: 2,
     });
 
     const worldBounds = window.L.latLngBounds(
@@ -230,12 +231,15 @@
         return;
       }
 
+      const safeZoom = Number.isFinite(zoom) ? zoom : 10;
+
       const map = window.L.map(container, {
         zoomControl: true,
         scrollWheelZoom: false,
         dragging: true,
         worldCopyJump: false,
         maxBoundsViscosity: 1,
+        minZoom: Math.max(3, Math.min(safeZoom, 12) - 2),
       });
 
       const worldBounds = window.L.latLngBounds(
@@ -244,7 +248,7 @@
       );
       map.setMaxBounds(worldBounds);
 
-      map.setView([lat, lng], Number.isFinite(zoom) ? zoom : 10);
+      map.setView([lat, lng], safeZoom);
 
       window.L
         .tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -259,8 +263,8 @@
         icon: window.L.divIcon({
           className: 'map-marker map-marker--mini',
           html: `<span aria-hidden="true">${container.dataset.markerEmoji || '📍'}</span>`,
-          iconSize: [28, 28],
-          iconAnchor: [14, 26],
+          iconSize: [36, 36],
+          iconAnchor: [18, 32],
         }),
         title: container.dataset.markerTitle || 'Ubicación del reto',
       });

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -663,7 +663,8 @@ nav {
   border-radius: var(--radius-lg);
   overflow: hidden;
   border: 1px solid var(--color-border);
-  min-height: clamp(320px, 55vh, 560px);
+  min-height: clamp(240px, 45vh, 460px);
+  aspect-ratio: 4 / 3;
   box-shadow: var(--shadow-sm);
   display: flex;
 }
@@ -693,13 +694,23 @@ nav {
   display: grid;
   place-items: center;
   border-radius: 50%;
-  font-size: 1.75rem;
+  font-size: clamp(2.1rem, 3vw, 2.6rem);
   color: #0f172a;
   text-shadow: 0 4px 12px rgba(15, 23, 42, 0.35);
 }
 
 .map-marker--mini {
-  font-size: 1.35rem;
+  font-size: clamp(1.6rem, 2.5vw, 1.9rem);
+}
+
+.leaflet-popup-content {
+  font-size: clamp(1rem, 1.8vw, 1.1rem);
+  line-height: 1.6;
+}
+
+.leaflet-popup-content h3 {
+  font-size: clamp(1.2rem, 2.1vw, 1.4rem);
+  margin-bottom: 0.4rem;
 }
 
 .map-popup {


### PR DESCRIPTION
## Summary
- reduce la altura mínima del mapa global y fija una proporción 4:3 para evitar desbordes verticales
- amplía marcadores y tipografía de los popups para mejorar la lectura en el mapa principal
- limita el nivel mínimo de zoom y ajusta los iconos en los mini mapas para conservar la escala adecuada

## Testing
- No automated tests were run (not applicable for this static site)


------
https://chatgpt.com/codex/tasks/task_b_68d703390a248329ad533c4b9985311a