### PR TITLE
Adjust global map layout

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -653,18 +653,21 @@ nav {
 #mapa-global {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 1fr);
   gap: var(--space-2xl);
-  align-items: stretch;
+  align-items: start;
   padding: calc(var(--nav-height) + var(--space-3xl)) 5vw var(--space-3xl);
+  max-width: min(1200px, 95vw);
+  margin-inline: auto;
+  min-height: auto;
 }
 
 #mapa-global .map-container {
   border-radius: var(--radius-lg);
   overflow: hidden;
   border: 1px solid var(--color-border);
-  min-height: clamp(240px, 45vh, 460px);
-  aspect-ratio: 4 / 3;
+  min-height: clamp(280px, 48vh, 520px);
+  max-height: 520px;
   box-shadow: var(--shadow-sm);
   display: flex;
 }


### PR DESCRIPTION
## Summary
- reduce the global map's column width and align the accompanying panel side-by-side within a centered container
- cap the map container height to prevent it from dominating the viewport on large screens

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d7060dc2a8832984f03782f1438a0e