### PR TITLE
Adjust global map layout proportions

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -653,7 +653,8 @@ nav {
 #mapa-global {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 1fr);
+  grid-template-columns: repeat(2, minmax(280px, 44%));
+  justify-content: center;
   gap: var(--space-2xl);
   align-items: start;
   padding: calc(var(--nav-height) + var(--space-3xl)) 5vw var(--space-3xl);


### PR DESCRIPTION
## Summary
- limit the global map and detail panel columns to 44% width each so they share the layout evenly
- center the two-column grid to keep the section balanced within the viewport

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d70762e0508329b9df69dccf5cccad