### PR TITLE
fix: improve browser compatibility for interactive scripts

### DIFF
--- a/docs/scripts/animations.js
+++ b/docs/scripts/animations.js
@@ -47,10 +47,10 @@
     if (!fallbackConfigPath || !fallbackImage) return fallbackImage;
 
     const config = await loadJsonConfig(fallbackConfigPath);
-    if (config?.src) {
+    if (config && config.src) {
       fallbackImage.src = config.src;
     }
-    if (config?.alt) {
+    if (config && config.alt) {
       fallbackImage.alt = config.alt;
     }
 
@@ -61,7 +61,7 @@
     if (!container) return;
     if (container.dataset.lottieHydrated === 'true') {
       const wrapper = container.closest('.reto-icon');
-      const fallbackImage = wrapper?.querySelector('[data-fallback-image]');
+      const fallbackImage = wrapper ? wrapper.querySelector('[data-fallback-image]') : null;
       if (reduceMotion) {
         if (wrapper) {
           wrapper.dataset.state = 'fallback';
@@ -132,8 +132,8 @@
         window.requestAnimationFrame(showAnimation);
       }
 
-      if (reduceMotion) {
-        animation.goToAndStop?.(0, true);
+      if (reduceMotion && typeof animation.goToAndStop === 'function') {
+        animation.goToAndStop(0, true);
       }
       container.dataset.lottieHydrated = 'true';
     } catch (error) {
@@ -492,7 +492,7 @@
     const kpis = document.querySelectorAll('.kpi');
     if (!kpis.length) return;
 
-    const CountUp = window.CountUp?.CountUp || window.CountUp;
+    const CountUp = window.CountUp && window.CountUp.CountUp ? window.CountUp.CountUp : window.CountUp;
 
     const observer = registerObserver(
       new IntersectionObserver((entries, obs) => {
@@ -500,7 +500,8 @@
           if (!entry.isIntersecting) return;
           const element = entry.target;
           const valueEl = element.querySelector('.kpi-value');
-          const target = Number.parseFloat(element.dataset.target || valueEl?.textContent || '0');
+          const fallbackText = valueEl ? valueEl.textContent : '0';
+          const target = Number.parseFloat(element.dataset.target || fallbackText || '0');
 
           if (!valueEl) {
             obs.unobserve(element);

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -79,7 +79,9 @@
       }
     }
 
-    window.feather?.replace();
+    if (window.feather && typeof window.feather.replace === 'function') {
+      window.feather.replace();
+    }
   }
 
   function getStoredTheme() {
@@ -246,7 +248,9 @@
       mapButton.className = 'reto-card__map';
       mapButton.textContent = 'Ver en el mapa';
       mapButton.addEventListener('click', () => {
-        window.MapManager?.focusOnReto(reto.id);
+        if (window.MapManager && typeof window.MapManager.focusOnReto === 'function') {
+          window.MapManager.focusOnReto(reto.id);
+        }
         highlightRetoCard(reto.id);
       });
       controls.appendChild(mapButton);
@@ -331,10 +335,17 @@
     initPrefetch();
     parseAndRenderRetos();
 
-    window.AnimationManager?.init();
-    window.MapManager?.initPage({ retosData: state.retosData });
+    if (window.AnimationManager && typeof window.AnimationManager.init === 'function') {
+      window.AnimationManager.init();
+    }
 
-    window.feather?.replace();
+    if (window.MapManager && typeof window.MapManager.initPage === 'function') {
+      window.MapManager.initPage({ retosData: state.retosData });
+    }
+
+    if (window.feather && typeof window.feather.replace === 'function') {
+      window.feather.replace();
+    }
 
     window.addEventListener('map:focus', onMapFocus);
     addCleanup(() => window.removeEventListener('map:focus', onMapFocus));
@@ -347,8 +358,13 @@
     }
 
     runCleanups();
-    window.AnimationManager?.destroy?.();
-    window.MapManager?.destroy?.();
+    if (window.AnimationManager && typeof window.AnimationManager.destroy === 'function') {
+      window.AnimationManager.destroy();
+    }
+
+    if (window.MapManager && typeof window.MapManager.destroy === 'function') {
+      window.MapManager.destroy();
+    }
   }
 
   function createOverlay() {

--- a/docs/scripts/media.js
+++ b/docs/scripts/media.js
@@ -66,7 +66,10 @@ docReady(() => {
    */
   const heroVideo = document.getElementById('bgVideo');
   const heroContainer = document.querySelector('.hero-video');
-  const motionFallback = heroContainer?.querySelector('[data-motion-disabled]');
+  let motionFallback = null;
+  if (heroContainer) {
+    motionFallback = heroContainer.querySelector('[data-motion-disabled]');
+  }
 
   const syncHeroVideo = () => {
     if (!heroVideo) return;
@@ -90,7 +93,11 @@ docReady(() => {
     }
   };
 
-  prefersReducedMotion.addEventListener?.('change', syncHeroVideo);
+  if (typeof prefersReducedMotion.addEventListener === 'function') {
+    prefersReducedMotion.addEventListener('change', syncHeroVideo);
+  } else if (typeof prefersReducedMotion.addListener === 'function') {
+    prefersReducedMotion.addListener(syncHeroVideo);
+  }
   syncHeroVideo();
 
   /**
@@ -128,24 +135,32 @@ docReady(() => {
         }
         try {
           await ambientAudio.play();
-          audioButton?.setAttribute('aria-pressed', 'true');
+          if (audioButton) {
+            audioButton.setAttribute('aria-pressed', 'true');
+          }
         } catch (error) {
           console.warn('Audio playback was prevented by the browser', error);
         }
       } else {
         ambientAudio.pause();
-        audioButton?.setAttribute('aria-pressed', 'false');
+        if (audioButton) {
+          audioButton.setAttribute('aria-pressed', 'false');
+        }
       }
     };
 
-    audioButton?.addEventListener('click', toggleAudio);
+    if (audioButton) {
+      audioButton.addEventListener('click', toggleAudio);
+    }
 
-    muteAll?.addEventListener('click', () => {
-      const isMuted = ambientAudio.muted;
-      ambientAudio.muted = !isMuted;
-      muteAll.setAttribute('aria-pressed', String(!isMuted));
-      muteAll.textContent = ambientAudio.muted ? '🔇' : '🔊';
-    });
+    if (muteAll) {
+      muteAll.addEventListener('click', () => {
+        const isMuted = ambientAudio.muted;
+        ambientAudio.muted = !isMuted;
+        muteAll.setAttribute('aria-pressed', String(!isMuted));
+        muteAll.textContent = ambientAudio.muted ? '🔇' : '🔊';
+      });
+    }
   }
 
   /**
@@ -175,8 +190,10 @@ docReady(() => {
               }
               if (el._lottie) {
                 if (entry.isIntersecting) {
-                  el._lottie.play();
-                } else {
+                  if (typeof el._lottie.play === 'function') {
+                    el._lottie.play();
+                  }
+                } else if (typeof el._lottie.pause === 'function') {
                   el._lottie.pause();
                 }
               }
@@ -187,7 +204,11 @@ docReady(() => {
 
           document.addEventListener('visibilitychange', () => {
             if (document.hidden) {
-              lottieTargets.forEach((target) => target._lottie?.pause());
+              lottieTargets.forEach((target) => {
+                if (target._lottie && typeof target._lottie.pause === 'function') {
+                  target._lottie.pause();
+                }
+              });
             }
           });
         })
@@ -292,7 +313,7 @@ docReady(() => {
             }
 
             const leafletModule = await import('https://unpkg.com/leaflet@1.9.4/dist/leaflet-src.esm.js');
-            const L = leafletModule.default ?? leafletModule;
+            const L = leafletModule && leafletModule.default ? leafletModule.default : leafletModule;
 
             const map = L.map('map', {
               zoomControl: true,
@@ -327,7 +348,10 @@ docReady(() => {
               .bindPopup(popupHtml);
 
             mapSection.dataset.state = 'loaded';
-            mapSection.querySelector('.map-placeholder')?.remove();
+            const placeholder = mapSection.querySelector('.map-placeholder');
+            if (placeholder && typeof placeholder.remove === 'function') {
+              placeholder.remove();
+            }
           } catch (error) {
             console.error('Error loading map resources', error);
             mapSection.dataset.state = 'error';


### PR DESCRIPTION
## Summary
- replace optional chaining usages across app, media, and animation scripts with defensive checks to avoid syntax errors in older browsers
- guard MapManager, AnimationManager, Feather Icons, and CountUp interactions so rendering logic only runs when the APIs are available

## Testing
- python3 -m http.server 8000 --directory docs & (served project locally for validation)
- playwright script to verify map tiles and reto cards render (Leaflet tile panes: 1, Cards: 4)


------
https://chatgpt.com/codex/tasks/task_b_68d70aabf7708329a790a95de19a140e