### PR TITLE
Adjust map section spacing

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -655,19 +655,20 @@ nav {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   justify-content: center;
-  gap: var(--space-2xl);
+  gap: clamp(var(--space-xl), 4vw, var(--space-2xl));
   align-items: stretch;
-  padding: calc(var(--nav-height) + var(--space-3xl)) 5vw var(--space-3xl);
-  max-width: min(1280px, 95vw);
+  align-content: start;
+  padding: calc(var(--nav-height) + var(--space-2xl)) clamp(3vw, 5vw, 6vw) var(--space-2xl);
+  max-width: min(1200px, 94vw);
   margin-inline: auto;
-  min-height: min(760px, 92vh);
+  min-height: auto;
 }
 
 #mapa-global .map-container {
   border-radius: var(--radius-lg);
   overflow: hidden;
   border: 1px solid var(--color-border);
-  min-height: clamp(320px, 65vh, 560px);
+  min-height: clamp(280px, 52vh, 480px);
   box-shadow: var(--shadow-sm);
   display: flex;
   background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.12), transparent 65%),
@@ -690,7 +691,7 @@ nav {
   gap: var(--space-lg);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
-  min-height: clamp(320px, 65vh, 560px);
+  min-height: clamp(280px, 52vh, 480px);
   grid-template-rows: auto auto 1fr auto;
   align-content: start;
 }
@@ -914,7 +915,7 @@ footer small {
 
   #mapa-global {
     grid-template-columns: 1fr;
-    padding: calc(var(--nav-height) + var(--space-2xl)) 6vw var(--space-3xl);
+    padding: calc(var(--nav-height) + var(--space-xl)) clamp(5vw, 8vw, 10vw) var(--space-xl);
   }
 }
 
@@ -943,7 +944,7 @@ footer small {
   }
 
   #mapa-global {
-    padding: calc(var(--nav-height) + var(--space-3xl)) clamp(5vw, 8vw, 12vw) var(--space-3xl);
+    padding: calc(var(--nav-height) + var(--space-2xl)) clamp(4vw, 6vw, 8vw) var(--space-2xl);
     grid-template-columns: minmax(420px, 1.15fr) minmax(380px, 0.95fr);
   }
 


### PR DESCRIPTION
## Summary
- reduce the map section padding and minimum heights so the content fits on screen without stretching
- tweak responsive spacing for the global map layout to keep the map and panel more compact on small and large viewports

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d70dadfc908329879274b936995abc