### PR TITLE
Ajusta distribución del mapa global

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -652,23 +652,28 @@ nav {
 /* ===== Mapa y panel ====================================================== */
 #mapa-global {
   position: relative;
+  --map-size: clamp(320px, min(62vw, 72vh), 560px);
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  justify-content: center;
+  justify-items: center;
   gap: clamp(var(--space-xl), 4vw, var(--space-2xl));
-  align-items: stretch;
-  align-content: start;
+  align-items: center;
+  align-content: center;
   padding: calc(var(--nav-height) + var(--space-2xl)) clamp(3vw, 5vw, 6vw) var(--space-2xl);
-  max-width: min(1200px, 94vw);
+  max-width: min(1160px, 96vw);
   margin-inline: auto;
-  min-height: auto;
+  min-height: calc(100vh - var(--nav-height) - var(--space-xl));
 }
 
 #mapa-global .map-container {
   border-radius: var(--radius-lg);
   overflow: hidden;
   border: 1px solid var(--color-border);
-  min-height: clamp(280px, 52vh, 480px);
+  width: min(100%, var(--map-size));
+  aspect-ratio: 1 / 1;
+  max-width: var(--map-size);
+  max-height: var(--map-size);
+  flex: none;
   box-shadow: var(--shadow-sm);
   display: flex;
   background: radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.12), transparent 65%),
@@ -682,6 +687,10 @@ nav {
   flex: 1;
 }
 
+#mapa-global .leaflet-container {
+  background: #9ecdf5;
+}
+
 .map-panel {
   padding: var(--space-2xl);
   border-radius: var(--radius-lg);
@@ -691,9 +700,11 @@ nav {
   gap: var(--space-lg);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
-  min-height: clamp(280px, 52vh, 480px);
+  width: min(100%, clamp(320px, 34vw, 420px));
+  max-height: var(--map-size);
   grid-template-rows: auto auto 1fr auto;
   align-content: start;
+  overflow: auto;
 }
 
 .map-panel [data-retos-list] {
@@ -914,8 +925,20 @@ footer small {
   }
 
   #mapa-global {
+    --map-size: clamp(240px, 78vw, 420px);
     grid-template-columns: 1fr;
+    justify-items: center;
+    min-height: auto;
     padding: calc(var(--nav-height) + var(--space-xl)) clamp(5vw, 8vw, 10vw) var(--space-xl);
+  }
+
+  #mapa-global .map-container {
+    width: min(100%, var(--map-size));
+  }
+
+  .map-panel {
+    width: min(100%, 520px);
+    max-height: none;
   }
 }
 
@@ -934,7 +957,8 @@ footer small {
   }
 
   #mapa-global {
-    grid-template-columns: minmax(360px, 1fr) minmax(360px, 1fr);
+    grid-template-columns: minmax(280px, var(--map-size)) minmax(320px, 1fr);
+    justify-items: center;
   }
 }
 
@@ -944,8 +968,9 @@ footer small {
   }
 
   #mapa-global {
+    --map-size: clamp(360px, min(48vw, 70vh), 600px);
     padding: calc(var(--nav-height) + var(--space-2xl)) clamp(4vw, 6vw, 8vw) var(--space-2xl);
-    grid-template-columns: minmax(420px, 1.15fr) minmax(380px, 0.95fr);
+    grid-template-columns: minmax(360px, var(--map-size)) minmax(360px, 0.95fr);
   }
 
   .hero-content {


### PR DESCRIPTION
## Summary
- Ajusta el layout del bloque del mapa global para que mapa y panel encajen completos en la vista.
- Mantiene el mapa con relación 1:1 y elimina fondos grises visibles durante el zoom.
- Limita la altura del panel lateral y habilita scroll interno en resoluciones pequeñas.

## Testing
- No automated tests were run (not applicable).


------
https://chatgpt.com/codex/tasks/task_b_68d70ee95e388329bc866cca5ac6f35a