### PR TITLE
feat: add horizontal scroll carousel for global map cards

### DIFF
--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -210,7 +210,8 @@
     if (!container) {
       container = document.createElement('div');
       container.dataset.retosList = 'true';
-      container.className = 'retos-grid';
+      container.className = 'map-card-scroller';
+      container.setAttribute('role', 'list');
       panel.insertBefore(container, details || panel.firstChild);
     }
 
@@ -220,6 +221,9 @@
       const card = document.createElement('article');
       card.className = 'reto-card';
       card.dataset.retoId = reto.id;
+      card.setAttribute('role', 'group');
+      card.setAttribute('aria-label', reto.nombre);
+      card.tabIndex = 0;
 
       if (reto.imagen) {
         const picture = document.createElement('img');
@@ -247,11 +251,18 @@
       mapButton.type = 'button';
       mapButton.className = 'reto-card__map';
       mapButton.textContent = 'Ver en el mapa';
-      mapButton.addEventListener('click', () => {
+
+      const focusReto = () => {
         if (window.MapManager && typeof window.MapManager.focusOnReto === 'function') {
           window.MapManager.focusOnReto(reto.id);
+        } else {
+          highlightRetoCard(reto.id);
         }
-        highlightRetoCard(reto.id);
+      };
+
+      mapButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        focusReto();
       });
       controls.appendChild(mapButton);
 
@@ -264,6 +275,21 @@
       }
 
       card.appendChild(controls);
+
+      card.addEventListener('click', (event) => {
+        if (event.target.closest('a, button')) {
+          return;
+        }
+        focusReto();
+      });
+
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          focusReto();
+        }
+      });
+
       container.appendChild(card);
     });
   }
@@ -278,8 +304,13 @@
     container.querySelectorAll('.reto-card').forEach((card) => {
       const isActive = card.dataset.retoId === retoId;
       card.classList.toggle('is-active', isActive);
+      card.setAttribute('aria-current', isActive ? 'true' : 'false');
       if (isActive) {
-        card.scrollIntoView({ block: 'nearest', behavior: prefersReducedMotion.matches ? 'auto' : 'smooth' });
+        card.scrollIntoView({
+          block: 'nearest',
+          inline: 'center',
+          behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+        });
       }
     });
   }

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -700,17 +700,13 @@ nav {
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
   width: min(100%, clamp(320px, 32vw, 460px));
-  max-height: calc(100% - var(--space-lg));
-  grid-template-rows: auto auto 1fr auto;
+  max-height: none;
+  grid-template-rows: auto auto auto auto;
   align-content: start;
-  overflow: auto;
+  overflow: visible;
 }
 
 .map-panel [data-retos-list] {
-  display: grid;
-  gap: var(--space-lg);
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-content: start;
   min-height: 0;
 }
 
@@ -774,14 +770,39 @@ nav {
 }
 
 /* ===== Tarjetas de retos adicionales ===================================== */
-.retos-grid {
+.map-card-scroller {
   display: grid;
-  gap: var(--space-xl);
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: clamp(240px, 72vw, 320px);
+  gap: clamp(var(--space-md), 3vw, var(--space-xl));
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-block-end: var(--space-sm);
+  padding-inline: clamp(var(--space-sm), 4vw, var(--space-lg));
+  margin-inline: calc(-1 * clamp(var(--space-sm), 4vw, var(--space-lg)));
+  scroll-snap-type: x mandatory;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.map-card-scroller::-webkit-scrollbar {
+  height: 8px;
+}
+
+.map-card-scroller::-webkit-scrollbar-track {
+  background: color-mix(in srgb, var(--color-surface-alt) 40%, transparent);
+  border-radius: 999px;
+}
+
+.map-card-scroller::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-accent-strong) 45%, transparent);
+  border-radius: 999px;
 }
 
 .map-panel [data-retos-list] .reto-card {
   height: 100%;
+  scroll-snap-align: center;
+  scroll-snap-stop: always;
 }
 
 .reto-card {
@@ -980,9 +1001,11 @@ footer small {
     align-items: center;
   }
 
-  .map-panel [data-retos-list] {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-md);
+  .map-card-scroller {
+    grid-auto-columns: clamp(240px, 28vw, 320px);
+    gap: clamp(var(--space-md), 2.5vw, var(--space-xl));
+    padding-inline: clamp(var(--space-md), 3vw, var(--space-xl));
+    margin-inline: calc(-1 * clamp(var(--space-md), 3vw, var(--space-xl)));
   }
 }
 


### PR DESCRIPTION
## Summary
- render the iniciativa cards in the global map panel inside a horizontal scroll scroller with keyboard and click handling
- keep map focus in sync by highlighting the active card and scrolling it into view
- restyle the map panel and cards to support snap scrolling and remove the old grid layout

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d7120f634083298720f7be67d28be1