### PR TITLE
Improve map section layout for initiative cards

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -653,6 +653,7 @@ nav {
 #mapa-global {
   position: relative;
   --map-size: clamp(340px, min(68vw, 72vh), 640px);
+  --panel-size: clamp(320px, 36vw, 440px);
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
@@ -699,11 +700,29 @@ nav {
   gap: var(--space-lg);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
-  width: min(100%, clamp(320px, 32vw, 460px));
+  width: min(100%, var(--panel-size));
   max-height: none;
   grid-template-rows: auto auto auto auto;
   align-content: start;
   overflow: visible;
+}
+
+@media (min-width: 960px) {
+  #mapa-global {
+    grid-template-columns: minmax(0, var(--map-size)) minmax(0, var(--panel-size));
+    justify-items: stretch;
+    align-items: stretch;
+  }
+
+  #mapa-global .map-container {
+    justify-self: stretch;
+  }
+
+  #mapa-global .map-panel {
+    width: 100%;
+    height: 100%;
+    align-self: stretch;
+  }
 }
 
 .map-panel [data-retos-list] {
@@ -783,6 +802,12 @@ nav {
   scroll-snap-type: x mandatory;
   overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
+}
+
+.map-card-scroller::after {
+  content: "";
+  display: block;
+  width: clamp(0px, 10vw, var(--space-2xl));
 }
 
 .map-card-scroller::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- align the map and initiative panel side by side on large screens to keep both visible
- tune the initiative card scroller for a smoother horizontal scroll experience

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d713b70a2c832988dbc28cee5e0554