### PR TITLE
Amplía la sección del mapa global

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -652,16 +652,16 @@ nav {
 /* ===== Mapa y panel ====================================================== */
 #mapa-global {
   position: relative;
-  --map-size: clamp(340px, min(68vw, 72vh), 640px);
-  --panel-size: clamp(320px, 36vw, 440px);
+  --map-size: clamp(420px, min(72vw, 78vh), 780px);
+  --panel-size: clamp(360px, 42vw, 560px);
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
-  gap: clamp(var(--space-lg), 3vw, var(--space-2xl));
+  gap: clamp(var(--space-xl), 4vw, var(--space-3xl));
   align-items: center;
   align-content: center;
-  padding: calc(var(--nav-height) + var(--space-2xl)) clamp(3vw, 4vw, 6vw) var(--space-2xl);
-  max-width: min(1400px, 98vw);
+  padding: calc(var(--nav-height) + var(--space-2xl)) clamp(2vw, 5vw, 8vw) var(--space-2xl);
+  max-width: min(1680px, 98vw);
   margin-inline: auto;
   min-height: calc(100vh - var(--nav-height) - var(--space-xl));
 }
@@ -672,7 +672,7 @@ nav {
   border: 1px solid var(--color-border);
   width: min(100%, var(--map-size));
   max-width: var(--map-size);
-  height: clamp(320px, 60vh, 640px);
+  height: clamp(360px, 65vh, 720px);
   flex: none;
   box-shadow: var(--shadow-sm);
   display: flex;
@@ -753,6 +753,7 @@ nav {
 .leaflet-popup-content {
   font-size: clamp(1rem, 1.8vw, 1.1rem);
   line-height: 1.6;
+  max-width: clamp(300px, 48vw, 380px);
 }
 
 .leaflet-popup-content h3 {
@@ -763,7 +764,7 @@ nav {
 .map-popup {
   display: grid;
   gap: var(--space-sm);
-  max-width: min(280px, 70vw);
+  max-width: clamp(300px, 48vw, 380px);
 }
 
 .map-popup img {


### PR DESCRIPTION
## Summary
- Amplía los anchos base del mapa global y de su panel para ocupar un mayor espacio horizontal.
- Ajusta las dimensiones de los popups del mapa para que muestren los retos con un contenedor más amplio.

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d716537ca483299d04bfa120b2eba9