### PR TITLE
Ancho de popups del mapa e imágenes ajustadas para retos

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -378,7 +378,7 @@
                 "nombre": "Transición energética",
                 "resumen": "Parques solares comunitarios en Atacama que abastecen a 1,2 millones de hogares.",
                 "coordenadas": [-24.385, -69.332],
-                "imagen": "https://source.unsplash.com/collection/2290905/800x600?solar",
+                "imagen": "https://images.unsplash.com/photo-1509395176047-4a66953fd231?auto=format&fit=crop&w=960&q=80",
                 "imagenAlt": "Vista aérea de paneles solares en el desierto de Atacama",
                 "ruta": "retos/reto-clima.html",
                 "emoji": "⚡"
@@ -388,7 +388,7 @@
                 "nombre": "Gestión del agua",
                 "resumen": "Desalinización con energías renovables para comunidades costeras en Marruecos.",
                 "coordenadas": [31.7917, -7.0926],
-                "imagen": "https://source.unsplash.com/collection/483251/800x600?desalination",
+                "imagen": "https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=960&q=80",
                 "imagenAlt": "Tuberías y depósitos de una planta de desalinización junto al mar",
                 "ruta": "retos/reto-agua.html",
                 "emoji": "💧"
@@ -398,7 +398,7 @@
                 "nombre": "Regenerar la biodiversidad",
                 "resumen": "Corredores biológicos amazónicos que conectan 12 reservas indígenas.",
                 "coordenadas": [-3.4653, -62.2159],
-                "imagen": "https://source.unsplash.com/collection/484351/800x600?rainforest",
+                "imagen": "https://images.unsplash.com/photo-1508780709619-79562169bc64?auto=format&fit=crop&w=960&q=80",
                 "imagenAlt": "Selva amazónica cubierta de niebla al amanecer",
                 "ruta": "retos/reto-biodiversidad.html",
                 "emoji": "🌱"
@@ -408,7 +408,7 @@
                 "nombre": "Ciudades circulares",
                 "resumen": "Red de movilidad eléctrica y reciclaje modular en Helsinki.",
                 "coordenadas": [60.1699, 24.9384],
-                "imagen": "https://source.unsplash.com/collection/483251/800x600?smart-city",
+                "imagen": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80",
                 "imagenAlt": "Tranvía eléctrico circulando por una avenida moderna de Helsinki",
                 "ruta": "retos/reto-aire.html",
                 "emoji": "🏙️"

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -753,7 +753,8 @@ nav {
 .leaflet-popup-content {
   font-size: clamp(1rem, 1.8vw, 1.1rem);
   line-height: 1.6;
-  max-width: clamp(360px, 52vw, 480px);
+  width: clamp(320px, 60vw, 560px);
+  max-width: none;
 }
 
 .leaflet-popup-content h3 {
@@ -764,12 +765,20 @@ nav {
 .map-popup {
   display: grid;
   gap: var(--space-sm);
-  max-width: clamp(360px, 52vw, 480px);
+  width: clamp(320px, 60vw, 560px);
+}
+
+@media (max-width: 600px) {
+  .leaflet-popup-content,
+  .map-popup {
+    width: min(88vw, 420px);
+  }
 }
 
 .map-popup img {
-  width: 100%;
+  width: clamp(140px, 38%, 200px);
   border-radius: var(--radius-md);
+  justify-self: center;
 }
 
 .map-popup__link {


### PR DESCRIPTION
## Summary
- ampliar los popups del mapa global para mejorar la legibilidad del contenido y mantener un comportamiento responsivo en móviles
- reemplazar las URLs aleatorias de Unsplash por imágenes consistentes de alta resolución para cada reto del mapa global
- reducir el tamaño de la imagen dentro del popup del mapa para que el hover sea más compacto y legible

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d71b71cea88329b5bace3cfe50a54a