### PR TITLE
Improve map popup header and media alignment

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -755,6 +755,9 @@ nav {
   line-height: 1.6;
   width: clamp(320px, 60vw, 560px);
   max-width: none;
+  margin: 0;
+  padding: clamp(var(--space-md), 2.4vw, var(--space-xl));
+  box-sizing: border-box;
 }
 
 .leaflet-popup-content h3 {
@@ -773,20 +776,33 @@ nav {
 
 .map-popup {
   display: grid;
-  gap: var(--space-sm);
+  gap: clamp(var(--space-sm), 1.4vw, var(--space-md));
   width: clamp(320px, 60vw, 560px);
   justify-items: center;
   animation: map-popup-rise var(--transition-long);
 }
 
-.map-popup > :is(header, p) {
-  justify-self: stretch;
+.map-popup header {
   width: 100%;
 }
 
 .map-popup header h3 {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  margin: 0;
+  padding: clamp(var(--space-2xs), 1vw, var(--space-sm))
+    clamp(var(--space-sm), 1.8vw, var(--space-md));
+  background: color-mix(in srgb, var(--color-surface-alt) 45%, transparent);
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-border) 35%, transparent);
   font-family: var(--font-heading);
   letter-spacing: 0.01em;
+}
+
+.map-popup > :is(header, p) {
+  justify-self: stretch;
+  width: 100%;
 }
 
 .map-popup__media {
@@ -799,6 +815,11 @@ nav {
   position: relative;
   overflow: hidden;
   justify-self: center;
+  margin-inline: auto;
+}
+
+.map-popup__media img {
+  display: block;
   margin-inline: auto;
 }
 


### PR DESCRIPTION
## Summary
- add internal padding to Leaflet popups so the header clears the close button area and feels more balanced
- restyle the popup heading and media container to keep the image centered and give the header a subtle elevated background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d72425ce548329ae4cf8278cecdb69