### PR TITLE
Refine map detail panel layout and reto card hover styling

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -731,6 +731,68 @@ nav {
 
 .map-panel .map-details {
   min-height: 0;
+  display: grid;
+  gap: clamp(var(--space-sm), 2vw, var(--space-lg));
+  padding: clamp(var(--space-lg), 3vw, var(--space-2xl));
+  text-align: center;
+  justify-items: center;
+  background: color-mix(in srgb, var(--color-surface-alt) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  border-radius: var(--radius-xl);
+  position: relative;
+  overflow: hidden;
+}
+
+.map-panel .map-details::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(14, 165, 233, 0.08), rgba(16, 185, 129, 0.08));
+  opacity: 0;
+  transition: opacity var(--transition-long);
+  pointer-events: none;
+}
+
+.map-panel[data-active-reto] .map-details::before {
+  opacity: 1;
+}
+
+.map-panel .map-details > * {
+  position: relative;
+  z-index: 1;
+}
+
+.map-panel .map-details img {
+  display: block;
+  width: min(100%, 280px);
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  margin-inline: auto;
+}
+
+.map-panel .map-details a[data-map-link] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  padding: var(--space-xs) clamp(var(--space-md), 4vw, var(--space-xl));
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--color-accent-strong);
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  box-shadow: 0 8px 24px rgba(14, 165, 233, 0.25);
+  transition: background-color var(--transition-base), color var(--transition-base),
+    transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.map-panel .map-details a[data-map-link]:is(:hover, :focus-visible) {
+  color: var(--color-surface);
+  background: color-mix(in srgb, var(--color-accent-strong) 92%, transparent);
+  transform: translateY(-3px) scale(1.01);
+  box-shadow: var(--shadow-md);
 }
 
 .map-panel[data-active-reto] .reto-card.is-active {
@@ -957,11 +1019,12 @@ nav {
 
 .map-panel [data-retos-list] .reto-card {
   position: relative;
+  z-index: 0;
   height: 100%;
   scroll-snap-align: center;
   scroll-snap-stop: always;
   transition: transform var(--transition-base), box-shadow var(--transition-base),
-    border-color var(--transition-base);
+    border-color var(--transition-base), background-color var(--transition-base);
   overflow: hidden;
 }
 
@@ -974,16 +1037,24 @@ nav {
   opacity: 0;
   transition: opacity var(--transition-base);
   pointer-events: none;
+  z-index: -1;
 }
 
 .map-panel [data-retos-list] .reto-card:is(:hover, :focus-visible, :focus-within) {
-  transform: translateY(-6px);
-  box-shadow: var(--shadow-md);
-  border-color: color-mix(in srgb, var(--color-accent-strong) 65%, transparent);
+  transform: translateY(-8px);
+  box-shadow: var(--shadow-lg);
+  border-color: color-mix(in srgb, var(--color-accent-strong) 55%, transparent);
+  background: color-mix(in srgb, var(--color-elevated) 80%, rgba(14, 165, 233, 0.2));
 }
 
 .map-panel [data-retos-list] .reto-card:is(:hover, :focus-visible, :focus-within)::after {
   opacity: 1;
+}
+
+.map-panel [data-retos-list] .reto-card__image {
+  display: block;
+  width: min(100%, 260px);
+  margin-inline: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- center the selected reto image and CTA inside the map detail panel with refreshed background treatment
- rebuild the reto card hover state so the highlight sits behind the content and the card lifts cleanly

## Testing
- Not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68d72682405c8329856c53919980fb87