### PR TITLE
Fix Leaflet asset loading and map hover behaviour

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin=""
+      crossorigin="anonymous"
     />
 
     <link rel="stylesheet" href="styles/main.css" />
@@ -67,7 +67,7 @@
     <script
       src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
       integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin=""
+      crossorigin="anonymous"
       defer
     ></script>
     <!-- CountUp.js -->

--- a/docs/retos/reto-agua.html
+++ b/docs/retos/reto-agua.html
@@ -38,8 +38,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin="anonymous"
     />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
@@ -404,8 +404,8 @@
 
     <script
       src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin="anonymous"
       defer
     ></script>
     <script src="../scripts/animations.js" defer></script>

--- a/docs/retos/reto-aire.html
+++ b/docs/retos/reto-aire.html
@@ -38,8 +38,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin="anonymous"
     />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
@@ -390,8 +390,8 @@
 
     <script
       src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin="anonymous"
       defer
     ></script>
     <script src="../scripts/animations.js" defer></script>

--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -38,8 +38,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin="anonymous"
     />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
@@ -390,8 +390,8 @@
 
     <script
       src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin="anonymous"
       defer
     ></script>
     <script src="../scripts/animations.js" defer></script>

--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -38,8 +38,8 @@
     <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin="anonymous"
     />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
@@ -387,8 +387,8 @@
 
     <script
       src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-o9N1j7kG6Lk4C0qVdLScqqfQjYkB7RviG3LrjPMo4n8="
-      crossorigin=""
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin="anonymous"
       defer
     ></script>
     <script src="../scripts/animations.js" defer></script>

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -385,7 +385,7 @@
     links.forEach((link) => {
       const href = link.getAttribute('href');
       if (!href || href.startsWith('#') || link.dataset.prefetchBound === 'true') return;
-      const url = new URL(href, window.location.origin);
+      const url = new URL(href, window.location.href);
       if (url.origin !== window.location.origin) return;
 
       const prefetch = () => {

--- a/docs/scripts/media.js
+++ b/docs/scripts/media.js
@@ -307,8 +307,8 @@ docReady(() => {
               const cssLink = document.createElement('link');
               cssLink.rel = 'stylesheet';
               cssLink.href = leafletCssHref;
-              cssLink.integrity = 'sha256-sA+e2kpawuO/7dBDEuDfSUdifYEYTbSsfXCMVbJbRMQ=';
-              cssLink.crossOrigin = '';
+              cssLink.integrity = 'sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=';
+              cssLink.crossOrigin = 'anonymous';
               document.head.append(cssLink);
             }
 

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -808,6 +808,15 @@ nav {
   text-shadow: 0 4px 12px rgba(15, 23, 42, 0.35);
 }
 
+.leaflet-marker-icon {
+  transition: none !important;
+}
+
+.leaflet-marker-icon:is(:hover, :focus) {
+  transform: none !important;
+  filter: none !important;
+}
+
 .map-marker--mini {
   font-size: clamp(1.6rem, 2.5vw, 1.9rem);
 }


### PR DESCRIPTION
## Summary
- update the Leaflet CDN references with the current integrity hashes and explicit anonymous CORS settings across all pages
- correct the client-side prefetch logic so internal links resolve within the published subdirectory
- align the lazy Leaflet loader with the new hash and remove hover animations from Leaflet markers

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68d731effd748329bb7fdcaaed8ae9d0