### PR TITLE
Add Helsinki circular cities reto page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -429,7 +429,7 @@
                 "coordenadas": [60.1699, 24.9384],
                 "imagen": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=960&q=80",
                 "imagenAlt": "Tranvía eléctrico circulando por una avenida moderna de Helsinki",
-                "ruta": "retos/reto-aire.html",
+                "ruta": "retos/reto-ciudades.html",
                 "emoji": "🏙️"
               }
             ]

--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -378,7 +378,7 @@
       <section class="reto-section" aria-label="Acciones finales" data-animate="section">
         <div class="reto-cta">
           <a class="reto-button is-primary" href="../index.html">Volver a la página principal</a>
-          <a class="reto-button" href="reto-clima.html">Ir al reto climático</a>
+          <a class="reto-button" href="reto-ciudades.html">Ir al reto de ciudades circulares</a>
         </div>
       </section>
     </main>

--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="es" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reto Ciudades | Sostenibilidad 2030</title>
+    <meta
+      name="description"
+      content="Caso sobre la estrategia circular de Helsinki con movilidad eléctrica, reutilización de materiales y barrios climáticamente neutros."
+    />
+    <meta name="keywords" content="ciudades circulares, Helsinki, economía circular, movilidad eléctrica" />
+    <meta name="author" content="Equipo Educativo Sostenibilidad 2030" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://ejemplo.org/sostenibilidad/retos/reto-ciudades" />
+    <meta property="og:title" content="Reto Ciudades | Sostenibilidad 2030" />
+    <meta
+      property="og:description"
+      content="Explora cómo Helsinki impulsa la circularidad urbana con movilidad compartida, energía renovable y reutilización de materiales."
+    />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1504384308090-c894fdcc538d" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:creator" content="@Sostenibilidad2030" />
+    <meta name="twitter:title" content="Reto Ciudades | Sostenibilidad 2030" />
+    <meta
+      name="twitter:description"
+      content="Análisis de la agenda Helsinki Circular 2035 con movilidad eléctrica y construcción modular."
+    />
+    <meta name="twitter:image" content="https://images.unsplash.com/photo-1504384308090-c894fdcc538d" />
+    <link rel="canonical" href="https://ejemplo.org/sostenibilidad/retos/reto-ciudades" />
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="../styles/retos.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
+  </head>
+  <body class="reto-page" data-reto="ciudades" data-barba="wrapper">
+    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+    <header class="reto-header">
+      <div class="reto-header__top">
+        <a class="reto-header__brand" href="../index.html">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 64 64"
+            role="img"
+            aria-hidden="true"
+          >
+            <circle cx="32" cy="32" r="30" fill="none" stroke="currentColor" stroke-width="3" />
+            <path
+              d="M18 36c10-4 16-12 18-24 8 8 12 20 6 32-4 8-12 12-20 10"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ></path>
+          </svg>
+          <span>Sostenibilidad 2030</span>
+        </a>
+        <div class="reto-header__meta">
+          <span class="reto-pill">Reto ciudades circulares</span>
+          <span>Helsinki · Finlandia</span>
+          <a href="#mapa">Ir al mapa</a>
+        </div>
+      </div>
+      <nav aria-label="Ruta de navegación">
+        <ol class="reto-breadcrumb">
+          <li><a href="../index.html">Inicio</a></li>
+          <li><a href="../index.html#retos">Retos</a></li>
+          <li aria-current="page">Ciudades circulares</li>
+        </ol>
+      </nav>
+    </header>
+
+    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-ciudades">
+      <section class="reto-hero" data-animate="section">
+        <div class="reto-hero__content" data-animate-item>
+          <span class="reto-hero__badge">Reto global 4</span>
+          <h1 class="reto-hero__title">Helsinki Circular 2035</h1>
+          <p class="reto-hero__summary">
+            La capital finlandesa apuesta por barrios climáticamente neutros, movilidad eléctrica compartida y reutilización de
+            materiales de obra para alcanzar la neutralidad de carbono en 2035. Kalasatama, distrito piloto, combina edificios
+            modulares, redes inteligentes y energía renovable gestionada por la comunidad.
+          </p>
+          <div class="reto-hero__actions">
+            <a class="reto-button is-primary" href="#cronologia">Revisar cronología</a>
+            <a class="reto-button" href="#fuentes">Consultar fuentes</a>
+          </div>
+          <div class="reto-hero__stats">
+            <div class="reto-stat" data-hover-card>
+              <strong>82&nbsp;%</strong>
+              <span>Residuos de construcción recuperados para nuevos proyectos municipales en 2023.</span>
+            </div>
+            <div class="reto-stat" data-hover-card>
+              <strong>1.200 puntos</strong>
+              <span>Infraestructura pública de carga eléctrica distribuida en la ciudad.</span>
+            </div>
+            <div class="reto-stat" data-hover-card>
+              <strong>75&nbsp;%</strong>
+              <span>Hogares de Kalasatama conectados a redes inteligentes con energía 100&nbsp;% renovable.</span>
+            </div>
+          </div>
+        </div>
+        <div class="reto-hero__media" data-animate-item>
+          <figure class="reto-hero__visual" aria-hidden="true">
+            <img
+              src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1000&q=80"
+              alt="Tranvía eléctrico circulando entre edificios sostenibles en Helsinki"
+              loading="lazy"
+              decoding="async"
+            />
+          </figure>
+          <div class="reto-hero__ornament" aria-hidden="true"></div>
+        </div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="resumen-caso" data-animate="section">
+        <header data-animate-item>
+          <h2 id="resumen-caso">Contexto del caso</h2>
+          <p>
+            Helsinki Circular 2035 integra movilidad, vivienda y consumo responsable para acelerar la transición hacia una
+            economía sin residuos. La municipalidad coordina con empresas de servicios públicos, universidades y ciudadanía
+            para crear cadenas de valor circulares en la construcción, la energía y la alimentación.
+          </p>
+        </header>
+        <div class="reto-grid-two">
+          <article data-animate-item>
+            <p>
+              El distrito de Kalasatama transforma un antiguo puerto en un barrio neutro en carbono. El tranvía rápido, los
+              ferris eléctricos y una red de ciclovías climatizadas reducen la dependencia del automóvil. Las viviendas cuentan
+              con sistemas de gestión energética que equilibran demanda y oferta en tiempo real.
+            </p>
+            <p>
+              La ciudad opera un centro de reutilización donde se clasifican materiales de demolición, paneles solares
+              recuperados y mobiliario urbano. Las plataformas digitales muestran disponibilidad de recursos y conectan a
+              cooperativas que fabrican nuevos productos con bajo impacto ambiental.
+            </p>
+          </article>
+          <article data-animate-item>
+            <figure class="reto-figure">
+              <img
+                src="https://images.unsplash.com/photo-1529429617124-aee3121fbb59?auto=format&fit=crop&w=900&q=80"
+                alt="Vecindario portuario de Helsinki con edificios modernos y áreas verdes"
+                loading="lazy"
+                decoding="async"
+              />
+              <figcaption>
+                Kalasatama es laboratorio urbano para servicios energéticos compartidos y logística de última milla libre de
+                emisiones.
+              </figcaption>
+            </figure>
+            <h3 id="aprendizajes">Aprendizajes clave</h3>
+            <p>
+              La estrategia demuestra que los municipios pueden liderar la circularidad imponiendo cláusulas de reutilización en
+              contratos públicos y ofreciendo incentivos fiscales a empresas que compartan datos de materiales. La ciudadanía
+              participa a través de presupuestos participativos que financian huertos en azoteas y hubs de reparación.
+            </p>
+            <p>
+              Los servicios de movilidad eléctrica se coordinan con empresas privadas y cooperativas vecinales. La integración
+              con el plan de calefacción distrital reduce un 20&nbsp;% la demanda energética en invierno y mejora el confort en
+              viviendas sociales.
+            </p>
+          </article>
+        </div>
+        <article class="reto-highlight" data-animate-item aria-labelledby="desafios">
+          <h3 id="desafios">Desafíos pendientes</h3>
+          <p>
+            Persisten retos para ampliar la infraestructura de reciclaje de baterías y asegurar que los materiales recuperados
+            cumplan estándares técnicos. Las empresas constructoras medianas solicitan apoyo financiero para adaptar procesos a
+            modelos circulares.
+          </p>
+          <p>
+            El ayuntamiento trabaja en acuerdos metropolitanos para llevar la logística eléctrica a barrios periféricos y
+            garantizar que la vivienda asequible acceda a los beneficios de la circularidad urbana.
+          </p>
+        </article>
+      </section>
+
+      <section class="reto-section" aria-labelledby="impacto-ambiental" data-animate="section">
+        <header data-animate-item>
+          <h2 id="impacto-ambiental">Impactos ambientales y sociales</h2>
+          <p>Resultados de la agenda circular en reducción de residuos, movilidad limpia y cohesión comunitaria.</p>
+        </header>
+        <div class="reto-impact-grid">
+          <article class="reto-impact" data-hover-card data-animate-item>
+            <h3>Impacto ambiental</h3>
+            <p>
+              El reciclaje de materiales de construcción evita 60&nbsp;000 toneladas de CO₂ equivalente al año. Los techos verdes
+              y parques lineales aumentan la absorción de agua pluvial y protegen frente a inundaciones en el litoral báltico.
+            </p>
+          </article>
+          <article class="reto-impact" data-hover-card data-animate-item>
+            <h3>Impacto social</h3>
+            <p>
+              Programas de formación en economía circular han beneficiado a 4&nbsp;500 personas, con énfasis en migrantes y
+              mujeres jóvenes que lideran cooperativas de reparación y reutilización.
+            </p>
+          </article>
+          <article class="reto-impact" data-hover-card data-animate-item>
+            <h3>Impacto económico</h3>
+            <p>
+              Las empresas involucradas en la red circular generaron 300 millones de euros en nuevos servicios digitales y
+              logísticos, fortaleciendo el ecosistema emprendedor local.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="cronologia" data-animate="section">
+        <header data-animate-item>
+          <h2 id="cronologia">Cronología del proceso</h2>
+          <p>Hitos clave para consolidar la circularidad urbana en Helsinki.</p>
+        </header>
+        <ol class="reto-timeline" data-animate-item>
+          <li>
+            <strong>2015</strong>
+            <span>Se lanza la visión Kalasatama Smart City con participación ciudadana y pilotos de energía inteligente.</span>
+          </li>
+          <li>
+            <strong>2018</strong>
+            <span>La ciudad adopta la hoja de ruta "Helsinki Circular Economy" con objetivos de reutilización del 50&nbsp;% de materiales.</span>
+          </li>
+          <li>
+            <strong>2020</strong>
+            <span>Inicio del programa de movilidad eléctrica compartida y estaciones de carga rápida en todos los distritos.</span>
+          </li>
+          <li>
+            <strong>2022</strong>
+            <span>Creación del banco digital de materiales de construcción y obligatoriedad en licitaciones públicas.</span>
+          </li>
+          <li>
+            <strong>2024</strong>
+            <span>Expansión del modelo circular a Pasila y Malmi con cooperativas de reutilización y redes de energía local.</span>
+          </li>
+        </ol>
+      </section>
+
+      <section class="reto-section map-section" aria-labelledby="mapa" data-animate="section">
+        <header data-animate-item>
+          <h2 id="mapa">Localización del caso</h2>
+          <p>Kalasatama (60.186° N, 24.979° E) es el epicentro de la estrategia circular de Helsinki.</p>
+        </header>
+        <div
+          id="map-ciudades"
+          role="application"
+          aria-label="Mapa de proyectos circulares de Helsinki"
+          data-map-lat="60.186"
+          data-map-lng="24.979"
+          data-map-zoom="13"
+          data-marker-title="Kalasatama, distrito circular"
+          data-marker-summary="Barrios neutros en carbono con movilidad eléctrica compartida y reutilización de materiales."
+          data-marker-image="https://images.unsplash.com/photo-1489515217757-5fd1be406fef"
+          data-marker-emoji="🏙️"
+          data-marker-route="../retos/reto-ciudades.html"
+        ></div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="fuentes" data-animate="section">
+        <header data-animate-item>
+          <h2 id="fuentes">Fuentes abiertas y recursos</h2>
+          <p>Documentos y plataformas para profundizar en la economía circular urbana de Helsinki.</p>
+        </header>
+        <ul class="reto-list">
+          <li>
+            <a href="https://www.hel.fi/en/urban-environment-and-traffic/circular-economy" target="_blank" rel="noopener"
+              >Ciudad de Helsinki · Circular Economy Program</a
+            >
+          </li>
+          <li>
+            <a href="https://www.sitra.fi/en/topics/carbon-neutral-circular-economy/" target="_blank" rel="noopener"
+              >Sitra · Economía circular y carbono neutral</a
+            >
+          </li>
+          <li>
+            <a href="https://smarthelsinki.fi" target="_blank" rel="noopener">Smart Helsinki · Proyectos piloto urbanos</a>
+          </li>
+        </ul>
+      </section>
+
+      <section class="reto-section" aria-label="Acciones finales" data-animate="section">
+        <div class="reto-cta">
+          <a class="reto-button is-primary" href="../index.html">Volver a la página principal</a>
+          <a class="reto-button" href="reto-clima.html">Ir al reto climático</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>
+      <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
+    </footer>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin="anonymous"
+      defer
+    ></script>
+    <script src="../scripts/animations.js" defer></script>
+    <script src="../scripts/map.js" defer></script>
+    <script src="../scripts/app.js" defer></script>
+  </body>
+</html>

--- a/docs/styles/retos.css
+++ b/docs/styles/retos.css
@@ -84,6 +84,16 @@ html[data-theme="dark"] .reto-page {
     linear-gradient(180deg, rgba(240, 253, 244, 0.94), rgba(34, 197, 94, 0.12));
 }
 
+.reto-page[data-reto="ciudades"] {
+  --reto-accent: #8b5cf6;
+  --reto-accent-strong: #7c3aed;
+  --reto-accent-soft: rgba(139, 92, 246, 0.16);
+  --reto-hero-image: url("https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=2000&q=80");
+  --reto-gradient: radial-gradient(circle at 18% 18%, rgba(129, 140, 248, 0.24), transparent 52%),
+    radial-gradient(circle at 82% 20%, rgba(139, 92, 246, 0.2), transparent 58%),
+    linear-gradient(180deg, rgba(237, 233, 254, 0.94), rgba(139, 92, 246, 0.12));
+}
+
 .reto-page[data-reto="clima"] {
   --reto-accent: #60a5fa;
   --reto-accent-strong: #2563eb;


### PR DESCRIPTION
## Summary
- point the ciudades reto entry in the homepage dataset to the new resource
- add a dedicated reto page for Helsinki's circular city initiative with map metadata and resources
- style the nuevas ciudades reto variant and link it into the circular navigation between retos

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68decb77a9948329a09719e43dd3be08