### PR TITLE
Respect reduced motion setting for hero video

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -137,6 +137,7 @@
       <section id="hero" aria-labelledby="hero-heading">
         <div class="hero-media" aria-hidden="true">
           <video
+            id="hero-video"
             src="assets/video/hero.mp4"
             autoplay
             muted
@@ -144,6 +145,13 @@
             playsinline
             poster="https://source.unsplash.com/collection/190727/1280x720?earth"
           ></video>
+          <div class="hero-media__fallback" data-hero-motion-fallback hidden>
+            <div class="hero-media__fallback-content">
+              <p>
+                La reproducción automática del vídeo se ha desactivado según tu preferencia de movimiento reducido.
+              </p>
+            </div>
+          </div>
         </div>
         <div class="hero-overlay" aria-hidden="true"></div>
         <div class="parallax-layer" data-depth="0.2" aria-hidden="true">

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -127,6 +127,66 @@
     toggle.dataset.themeBound = 'true';
   }
 
+  function initHeroMotionPreference() {
+    const heroVideo = document.getElementById('hero-video');
+    if (!heroVideo) return;
+
+    const fallback = document.querySelector('[data-hero-motion-fallback]');
+    const shouldAutoplay = heroVideo.hasAttribute('autoplay');
+
+    if (fallback) {
+      const poster = heroVideo.getAttribute('poster');
+      if (poster) {
+        fallback.style.setProperty('--hero-fallback-image', `url("${poster}")`);
+      }
+    }
+
+    const applyPreference = (reduceMotion) => {
+      if (reduceMotion) {
+        heroVideo.pause();
+        heroVideo.removeAttribute('autoplay');
+        if (fallback) {
+          fallback.hidden = false;
+        }
+      } else {
+        if (fallback) {
+          fallback.hidden = true;
+        }
+        if (shouldAutoplay) {
+          heroVideo.setAttribute('autoplay', '');
+        }
+        const playPromise = heroVideo.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch(() => {});
+        }
+      }
+    };
+
+    const handleMotionChange = (event) => {
+      const matches = event && typeof event.matches === 'boolean' ? event.matches : prefersReducedMotion.matches;
+      applyPreference(matches);
+    };
+
+    applyPreference(prefersReducedMotion.matches);
+
+    if (typeof prefersReducedMotion.addEventListener === 'function') {
+      prefersReducedMotion.addEventListener('change', handleMotionChange);
+      addCleanup(() => prefersReducedMotion.removeEventListener('change', handleMotionChange));
+    } else if (typeof prefersReducedMotion.addListener === 'function') {
+      prefersReducedMotion.addListener(handleMotionChange);
+      addCleanup(() => prefersReducedMotion.removeListener(handleMotionChange));
+    }
+
+    addCleanup(() => {
+      if (fallback) {
+        fallback.hidden = true;
+      }
+      if (shouldAutoplay && !prefersReducedMotion.matches) {
+        heroVideo.setAttribute('autoplay', '');
+      }
+    });
+  }
+
   function focusMain(initial = false) {
     const main = document.querySelector('#contenido-principal');
     if (!main) return;
@@ -625,6 +685,7 @@
   function initPage() {
     ensureLazyImages();
     initThemeToggle();
+    initHeroMotionPreference();
     initMobileMenu();
     initNavHighlight();
     initPrefetch();

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -555,6 +555,33 @@ body.has-mobile-nav-open {
   filter: brightness(0.65);
 }
 
+.hero-media__fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.78), rgba(15, 23, 42, 0.82)),
+    var(--hero-fallback-image, #0f172a);
+  background-size: cover;
+  background-position: center;
+  color: #f8fafc;
+  transition: opacity 0.3s ease;
+}
+
+.hero-media__fallback[hidden] {
+  opacity: 0;
+}
+
+.hero-media__fallback-content {
+  max-width: min(520px, 80vw);
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.01em;
+}
+
 .hero-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- detect the reduced-motion preference during page init and configure the hero video behaviour
- display a static fallback background and message when autoplay is disabled to avoid CLS in the hero
- listen for media query changes to resume or pause playback and clean up listeners during teardown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68decdb253a483299fde25127322f263