### PR TITLE
Lazy load Leaflet dependencies on demand

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,14 +45,6 @@
       rel="stylesheet"
     />
 
-    <!-- Leaflet CSS -->
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin="anonymous"
-    />
-
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="stylesheet" href="styles/icons.css" />
     <link rel="stylesheet" href="styles/retos.css" />
@@ -63,15 +55,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
     <!-- Barba.js -->
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
-    <!-- Leaflet JS -->
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin="anonymous"
-      defer
-    ></script>
-    <!-- CountUp.js -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/countup.js/2.8.0/countUp.umd.js" defer></script>
     <!-- Feather Icons -->
     <script src="https://unpkg.com/feather-icons" defer></script>
   </head>

--- a/docs/retos/reto-agua.html
+++ b/docs/retos/reto-agua.html
@@ -35,12 +35,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin="anonymous"
-    />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
@@ -402,12 +396,6 @@
       <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
     </footer>
 
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin="anonymous"
-      defer
-    ></script>
     <script src="../scripts/animations.js" defer></script>
     <script src="../scripts/map.js" defer></script>
     <script src="../scripts/app.js" defer></script>

--- a/docs/retos/reto-aire.html
+++ b/docs/retos/reto-aire.html
@@ -35,12 +35,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin="anonymous"
-    />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
@@ -388,12 +382,6 @@
       <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
     </footer>
 
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin="anonymous"
-      defer
-    ></script>
     <script src="../scripts/animations.js" defer></script>
     <script src="../scripts/map.js" defer></script>
     <script src="../scripts/app.js" defer></script>

--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -35,12 +35,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin="anonymous"
-    />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
@@ -388,12 +382,6 @@
       <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
     </footer>
 
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin="anonymous"
-      defer
-    ></script>
     <script src="../scripts/animations.js" defer></script>
     <script src="../scripts/map.js" defer></script>
     <script src="../scripts/app.js" defer></script>

--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -35,12 +35,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin="anonymous"
-    />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
@@ -302,12 +296,6 @@
       <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
     </footer>
 
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin="anonymous"
-      defer
-    ></script>
     <script src="../scripts/animations.js" defer></script>
     <script src="../scripts/map.js" defer></script>
     <script src="../scripts/app.js" defer></script>

--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -35,12 +35,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-      crossorigin="anonymous"
-    />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
@@ -385,12 +379,6 @@
       <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
     </footer>
 
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin="anonymous"
-      defer
-    ></script>
     <script src="../scripts/animations.js" defer></script>
     <script src="../scripts/map.js" defer></script>
     <script src="../scripts/app.js" defer></script>


### PR DESCRIPTION
## Summary
- remove the static Leaflet style/script tags from the home and reto pages so the library can be loaded on demand
- add an IntersectionObserver-powered loader in `docs/scripts/app.js` that injects Leaflet CSS, Leaflet, CountUp, and GSAP/ScrollTrigger only when a map enters the viewport and hydrates `MapManager`
- update `docs/scripts/map.js` to work with deferred Leaflet instances, clearing fallbacks and reinitializing global and mini maps once the library is available

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ded366ebdc832991151da283400573