### PR TITLE
Create Atacama energy case and fix map focus initialization

### DIFF
--- a/docs/assets/img/solar-atacama-comunidad.svg
+++ b/docs/assets/img/solar-atacama-comunidad.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 520" role="img" aria-labelledby="title desc">
+  <title id="title">Cooperativa solar comunitaria de Atacama</title>
+  <desc id="desc">Ilustración de una comunidad organizada frente a paneles solares y una red eléctrica.</desc>
+  <defs>
+    <linearGradient id="ground" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f59e0b" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="760" height="520" fill="#fefce8" />
+  <path d="M0 360 L760 360 L760 520 L0 520 Z" fill="url(#ground)" />
+  <g stroke="#fbbf24" stroke-width="6" fill="none">
+    <path d="M80 180 Q200 100 320 180 T560 180" />
+    <circle cx="80" cy="180" r="10" fill="#facc15" />
+    <circle cx="320" cy="180" r="10" fill="#facc15" />
+    <circle cx="560" cy="180" r="10" fill="#facc15" />
+  </g>
+  <g transform="translate(140,260) skewX(-8)">
+    <rect width="180" height="90" rx="8" fill="url(#panel)" />
+    <line x1="0" y1="30" x2="180" y2="30" stroke="#60a5fa" stroke-width="2" />
+    <line x1="0" y1="60" x2="180" y2="60" stroke="#60a5fa" stroke-width="2" />
+  </g>
+  <g transform="translate(360,290) skewX(-8)">
+    <rect width="200" height="90" rx="8" fill="url(#panel)" />
+    <line x1="0" y1="30" x2="200" y2="30" stroke="#60a5fa" stroke-width="2" />
+    <line x1="0" y1="60" x2="200" y2="60" stroke="#60a5fa" stroke-width="2" />
+  </g>
+  <g fill="#0f172a">
+    <circle cx="180" cy="340" r="30" />
+    <path d="M160 380 Q180 400 200 380" fill="#0f172a" />
+    <circle cx="320" cy="340" r="30" />
+    <path d="M300 380 Q320 400 340 380" fill="#0f172a" />
+    <circle cx="460" cy="340" r="30" />
+    <path d="M440 380 Q460 400 480 380" fill="#0f172a" />
+  </g>
+  <g fill="#fb923c">
+    <circle cx="220" cy="350" r="18" />
+    <path d="M205 380 Q220 398 235 380" fill="#fb923c" />
+    <circle cx="360" cy="350" r="18" />
+    <path d="M345 380 Q360 398 375 380" fill="#fb923c" />
+    <circle cx="500" cy="350" r="18" />
+    <path d="M485 380 Q500 398 515 380" fill="#fb923c" />
+  </g>
+</svg>

--- a/docs/assets/img/solar-atacama-hero.svg
+++ b/docs/assets/img/solar-atacama-hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" role="img" aria-labelledby="title desc">
+  <title id="title">Planta solar en el desierto de Atacama</title>
+  <desc id="desc">Ilustración de paneles solares frente a montañas y un sol naciente.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fcd34d" />
+      <stop offset="60%" stop-color="#fde68a" />
+      <stop offset="100%" stop-color="#fef3c7" />
+    </linearGradient>
+    <linearGradient id="sand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f59e0b" />
+      <stop offset="100%" stop-color="#fbbf24" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#1e40af" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" fill="url(#sky)" />
+  <path d="M0 420 L200 300 L420 360 L600 280 L820 360 L960 320 L960 640 L0 640 Z" fill="url(#sand)" />
+  <g fill="#fff3" stroke="#ffffff22" stroke-width="2">
+    <circle cx="720" cy="160" r="78" />
+    <circle cx="720" cy="160" r="110" fill="none" />
+  </g>
+  <g transform="translate(80,360) skewX(-8)">
+    <rect x="0" y="0" width="220" height="120" rx="10" fill="url(#panel)" />
+    <line x1="0" y1="40" x2="220" y2="40" stroke="#60a5fa" stroke-width="2" />
+    <line x1="0" y1="80" x2="220" y2="80" stroke="#60a5fa" stroke-width="2" />
+  </g>
+  <g transform="translate(320,400) skewX(-8)">
+    <rect x="0" y="0" width="240" height="120" rx="10" fill="url(#panel)" />
+    <line x1="0" y1="40" x2="240" y2="40" stroke="#60a5fa" stroke-width="2" />
+    <line x1="0" y1="80" x2="240" y2="80" stroke="#60a5fa" stroke-width="2" />
+  </g>
+  <g transform="translate(600,360) skewX(-8)">
+    <rect x="0" y="0" width="220" height="120" rx="10" fill="url(#panel)" />
+    <line x1="0" y1="40" x2="220" y2="40" stroke="#60a5fa" stroke-width="2" />
+    <line x1="0" y1="80" x2="220" y2="80" stroke="#60a5fa" stroke-width="2" />
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -386,11 +386,11 @@
               {
                 "id": "energia",
                 "nombre": "Transición energética",
-                "resumen": "Parques solares comunitarios en Atacama que abastecen a 1,2 millones de hogares.",
+                "resumen": "Cooperativas solares en Atacama financian energía limpia para el norte de Chile.",
                 "coordenadas": [-24.385, -69.332],
-                "imagen": "https://images.unsplash.com/photo-1509395176047-4a66953fd231?auto=format&fit=crop&w=960&q=80",
-                "imagenAlt": "Vista aérea de paneles solares en el desierto de Atacama",
-                "ruta": "retos/reto-clima.html",
+                "imagen": "assets/img/solar-atacama-hero.svg",
+                "imagenAlt": "Ilustración de paneles solares cooperativos en el desierto de Atacama",
+                "ruta": "retos/reto-energia.html",
                 "emoji": "⚡"
               },
               {

--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -369,7 +369,7 @@
       <section class="reto-section" aria-label="Acciones finales" data-animate="section">
         <div class="reto-cta">
           <a class="reto-button is-primary" href="../index.html">Volver a la página principal</a>
-          <a class="reto-button" href="reto-agua.html">Volver al reto de agua</a>
+          <a class="reto-button" href="reto-energia.html">Ir al reto de transición energética</a>
         </div>
       </section>
     </main>

--- a/docs/retos/reto-energia.html
+++ b/docs/retos/reto-energia.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="es" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reto Energía | Sostenibilidad 2030</title>
+    <meta
+      name="description"
+      content="Cooperativas solares comunitarias en Atacama que proveen energía limpia y asequible a hogares del norte de Chile."
+    />
+    <meta name="keywords" content="energía solar, Atacama, transición energética, cooperativas" />
+    <meta name="author" content="Equipo Educativo Sostenibilidad 2030" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://ejemplo.org/sostenibilidad/retos/reto-energia" />
+    <meta property="og:title" content="Reto Energía | Sostenibilidad 2030" />
+    <meta
+      property="og:description"
+      content="Explora cómo las comunidades de Atacama impulsan parques solares compartidos que abastecen a más de un millón de hogares."
+    />
+    <meta property="og:image" content="https://ejemplo.org/sostenibilidad/assets/og-energia.jpg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:creator" content="@Sostenibilidad2030" />
+    <meta name="twitter:title" content="Reto Energía | Sostenibilidad 2030" />
+    <meta
+      name="twitter:description"
+      content="Casos de transición energética justa en el desierto de Atacama con participación comunitaria."
+    />
+    <meta name="twitter:image" content="https://ejemplo.org/sostenibilidad/assets/twitter-energia.jpg" />
+    <link rel="canonical" href="https://ejemplo.org/sostenibilidad/retos/reto-energia" />
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles/retos.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
+  </head>
+  <body class="reto-page" data-reto="energia" data-barba="wrapper">
+    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+    <header class="reto-header">
+      <div class="reto-header__top">
+        <a class="reto-header__brand" href="../index.html">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 64 64"
+            role="img"
+            aria-hidden="true"
+          >
+            <circle cx="32" cy="32" r="30" fill="none" stroke="currentColor" stroke-width="3" />
+            <path
+              d="M18 36c10-4 16-12 18-24 8 8 12 20 6 32-4 8-12 12-20 10"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            ></path>
+          </svg>
+          <span>Sostenibilidad 2030</span>
+        </a>
+        <div class="reto-header__meta">
+          <span class="reto-pill">Reto energía</span>
+          <span>María Elena · Desierto de Atacama</span>
+          <a href="#mapa">Ir al mapa</a>
+        </div>
+      </div>
+      <nav aria-label="Ruta de navegación">
+        <ol class="reto-breadcrumb">
+          <li><a href="../index.html">Inicio</a></li>
+          <li><a href="../index.html#retos">Retos</a></li>
+          <li aria-current="page">Transición energética</li>
+        </ol>
+      </nav>
+    </header>
+
+    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-energia">
+      <section class="reto-hero" data-animate="section">
+        <div class="reto-hero__content" data-animate-item>
+          <span class="reto-hero__badge">Reto global 1</span>
+          <h1 class="reto-hero__title">Energía comunitaria para el Norte Grande</h1>
+          <p class="reto-hero__summary">
+            La comuna de María Elena lidera un consorcio de cooperativas solares que inyectan energía limpia a la red
+            chilena. Los parques fotovoltaicos se diseñan junto a comunidades atacameñas, priorizan el empleo local y
+            destinan excedentes a programas de electrificación rural y almacenamiento comunitario.
+          </p>
+          <div class="reto-hero__actions">
+            <a class="reto-button is-primary" href="#mapa">Explorar ubicación</a>
+            <a class="reto-button" href="#fuentes">Ver fuentes abiertas</a>
+          </div>
+          <div class="reto-hero__stats">
+            <div class="reto-stat" data-hover-card>
+              <strong>1,2&nbsp;millones</strong>
+              <span>Hogares abastecidos con contratos de energía compartida.</span>
+            </div>
+            <div class="reto-stat" data-hover-card>
+              <strong>280&nbsp;MW</strong>
+              <span>Capacidad solar comunitaria operativa con trackers bifaciales.</span>
+            </div>
+            <div class="reto-stat" data-hover-card>
+              <strong>5&nbsp;GWh</strong>
+              <span>Capacidad de almacenamiento en baterías para estabilizar la red local.</span>
+            </div>
+          </div>
+        </div>
+        <div class="reto-hero__media" data-animate-item>
+          <figure class="reto-hero__visual" aria-hidden="true">
+            <img
+              src="../assets/img/solar-atacama-hero.svg"
+              alt="Ilustración de paneles solares al amanecer en el desierto de Atacama"
+              loading="lazy"
+              decoding="async"
+            />
+          </figure>
+          <div class="reto-hero__ornament" aria-hidden="true"></div>
+        </div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="resumen-caso" data-animate="section">
+        <header data-animate-item>
+          <h2 id="resumen-caso">Contexto del caso</h2>
+          <p>
+            El extremo norte de Chile concentra el 40&nbsp;% de la irradiación solar de América Latina, pero muchas
+            localidades rurales dependen aún de generadores diésel. En 2019 el municipio de María Elena y cooperativas de
+            vecinos impulsaron un modelo de generación distribuida que combina parques solares, microredes y fondos de
+            transición justa.
+          </p>
+        </header>
+        <div class="reto-grid-two">
+          <article data-animate-item>
+            <p>
+              Las comunidades indígenas lideraron consultas tempranas para definir la ubicación de los parques y proteger
+              sitios ceremoniales. Los contratos de arriendo establecen pagos escalonados, inversión en agua y educación
+              técnica para jóvenes. Empresas locales administran los trackers y sistemas SCADA mientras que la cooperativa
+              coordina los acuerdos de compra de energía (PPAs) con la empresa distribuidora Transelec.
+            </p>
+            <p>
+              El proyecto incluye centros de control en Tocopilla que integran datos meteorológicos, pronósticos de
+              demanda y algoritmos de optimización. La energía excedente se almacena en baterías de flujo y se entrega a
+              tarifas sociales para postas rurales. Los beneficios se auditan en una mesa público-comunitaria que reporta
+              avances trimestralmente.
+            </p>
+          </article>
+          <article data-animate-item>
+            <figure class="reto-figure">
+              <img
+                src="../assets/img/solar-atacama-comunidad.svg"
+                alt="Ilustración de una cooperativa solar coordinando paneles y red eléctrica"
+                loading="lazy"
+                decoding="async"
+              />
+              <figcaption>
+                Cooperativas atacameñas administran los parques mediante acuerdos de gobernanza compartida y fideicomisos
+                locales.
+              </figcaption>
+            </figure>
+            <h3 id="aprendizajes">Aprendizajes clave</h3>
+            <ul class="reto-list">
+              <li>
+                <strong>Propiedad compartida:</strong> los habitantes poseen participaciones del 35&nbsp;% en cada planta y
+                acceden a dividendos por producción.
+              </li>
+              <li>
+                <strong>Diseño biofísico:</strong> mapeos solares y de biodiversidad guiaron corredores para fauna y
+                reubicación de cactus endémicos.
+              </li>
+              <li>
+                <strong>Transparencia financiera:</strong> los PPAs comunitarios se publican en un portal abierto con
+                alertas sobre costos y emisiones evitadas.
+              </li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="impactos" data-animate="section">
+        <header data-animate-item>
+          <h2 id="impactos">Impactos medidos</h2>
+          <p>
+            Indicadores ambientales y sociales monitoreados por el Ministerio de Energía, la Superintendencia de
+            Electricidad y las cooperativas.
+          </p>
+        </header>
+        <div class="reto-grid-three">
+          <article class="reto-card" data-hover-card data-animate-item>
+            <h3>Emisiones evitadas</h3>
+            <p>1,8 millones de toneladas de CO₂ evitadas durante la primera década de operación.</p>
+          </article>
+          <article class="reto-card" data-hover-card data-animate-item>
+            <h3>Tarifa social</h3>
+            <p>39&nbsp;% de reducción promedio en las cuentas eléctricas de viviendas rurales conectadas.</p>
+          </article>
+          <article class="reto-card" data-hover-card data-animate-item>
+            <h3>Empleo local</h3>
+            <p>2&nbsp;600 puestos directos durante la construcción y 480 empleos permanentes para operación y mantención.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="mapa" data-animate="section">
+        <header data-animate-item>
+          <h2 id="mapa">Localización del caso</h2>
+          <p>Los parques solares se sitúan entre María Elena y Calama, a más de 2&nbsp;200 metros de altitud.</p>
+        </header>
+        <div
+          id="map-energia"
+          role="application"
+          aria-label="Mapa de la transición energética en Atacama"
+          data-map-lat="-24.385"
+          data-map-lng="-69.332"
+          data-map-zoom="8"
+          data-marker-title="Parques solares cooperativos de María Elena"
+          data-marker-summary="Plantas fotovoltaicas comunitarias que abastecen al norte de Chile."
+          data-marker-image="../assets/img/solar-atacama-hero.svg"
+          data-marker-emoji="⚡"
+          data-marker-route="../retos/reto-energia.html"
+        ></div>
+      </section>
+
+      <section class="reto-section" aria-labelledby="fuentes" data-animate="section">
+        <header data-animate-item>
+          <h2 id="fuentes">Fuentes abiertas y recursos</h2>
+          <p>Documentos y plataformas que respaldan la gobernanza energética comunitaria en Atacama.</p>
+        </header>
+        <ul class="reto-list">
+          <li><a href="https://energia.gob.cl" target="_blank" rel="noopener">Ministerio de Energía de Chile</a></li>
+          <li><a href="https://cooperativasolar.cl" target="_blank" rel="noopener">Cooperativa Solar del Norte Grande</a></li>
+          <li><a href="https://coordinador.cl" target="_blank" rel="noopener">Coordinador Eléctrico Nacional · Panel público</a></li>
+        </ul>
+      </section>
+
+      <section class="reto-section" aria-label="Acciones finales" data-animate="section">
+        <div class="reto-cta">
+          <a class="reto-button is-primary" href="../index.html">Volver a la página principal</a>
+          <a class="reto-button" href="reto-agua.html">Ir al reto de gestión del agua</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>
+      <small>Datos cartográficos &copy; OpenStreetMap colaboradores. Contenido de libre uso para fines académicos.</small>
+    </footer>
+
+    <script src="../scripts/animations.js" defer></script>
+    <script src="../scripts/map.js" defer></script>
+    <script src="../scripts/app.js" defer></script>
+  </body>
+</html>

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -838,6 +838,11 @@
       mapButton.textContent = 'Ver en el mapa';
 
       const focusReto = () => {
+        const dependenciesPromise = loadMapDependencies();
+        if (dependenciesPromise && typeof dependenciesPromise.catch === 'function') {
+          dependenciesPromise.catch(() => {});
+        }
+
         if (window.MapManager && typeof window.MapManager.focusOnReto === 'function') {
           window.MapManager.focusOnReto(reto.id);
         } else {

--- a/docs/scripts/map.js
+++ b/docs/scripts/map.js
@@ -244,6 +244,10 @@
     state.globalMap = map;
     state.maps.set(container, map);
     updateDetails(null);
+
+    if (state.activeRetoId) {
+      focusOnReto(state.activeRetoId);
+    }
   }
 
   function initMiniMaps() {
@@ -363,13 +367,17 @@
 
   function focusOnReto(retoId) {
     if (!retoId) return;
-    const marker = state.globalMarkers.get(retoId);
     const reto = state.retos.find((item) => item.id === retoId);
-    if (!marker || !reto) return;
+    if (!reto) return;
 
     state.activeRetoId = retoId;
     updateDetails(reto);
     window.dispatchEvent(new CustomEvent('map:focus', { detail: retoId }));
+
+    const marker = state.globalMarkers.get(retoId);
+    if (!marker) {
+      return;
+    }
 
     if (state.globalMap && marker.getLatLng) {
       const duration = prefersReducedMotion.matches ? 0 : 0.85;

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -7,6 +7,9 @@
     <loc>retos/reto-clima.html</loc>
   </url>
   <url>
+    <loc>retos/reto-energia.html</loc>
+  </url>
+  <url>
     <loc>retos/reto-agua.html</loc>
   </url>
   <url>
@@ -14,5 +17,8 @@
   </url>
   <url>
     <loc>retos/reto-aire.html</loc>
+  </url>
+  <url>
+    <loc>retos/reto-ciudades.html</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a dedicated transición energética case page for the Atacama community solar project with local artwork and content
- update the home data, sitemap, and reto navigation so the energy challenge links correctly
- adjust the map focus flow to trigger even before Leaflet markers exist and load dependencies when CTAs are used

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68e822de4bc083299425f9b0410e14ce