### PR TITLE
Sync body state with Barba containers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,9 +59,10 @@
     <script src="https://unpkg.com/feather-icons" defer></script>
   </head>
   <body data-barba="wrapper">
-    <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+    <div data-barba="container" data-barba-namespace="home" data-body-class="">
+      <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
 
-    <header>
+      <header>
       <nav aria-label="Menú principal">
         <a class="brand" href="#hero">
           <span class="sr-only">Ir al inicio</span>
@@ -114,9 +115,9 @@
           </button>
         </div>
       </nav>
-    </header>
+      </header>
 
-    <main id="contenido-principal" data-barba="container" data-barba-namespace="home">
+      <main id="contenido-principal">
       <section id="hero" aria-labelledby="hero-heading">
         <div class="hero-media" aria-hidden="true">
           <video
@@ -427,7 +428,8 @@
           }
         </script>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer id="footer">
       <div>

--- a/docs/retos/reto-agua.html
+++ b/docs/retos/reto-agua.html
@@ -41,8 +41,14 @@
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
   </head>
   <body class="reto-page" data-reto="agua" data-barba="wrapper">
-    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header class="reto-header">
+    <div
+      data-barba="container"
+      data-barba-namespace="reto-agua"
+      data-body-class="reto-page"
+      data-reto="agua"
+    >
+      <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+      <header class="reto-header">
       <div class="reto-header__top">
         <a class="reto-header__brand" href="../index.html">
           <svg
@@ -78,7 +84,7 @@
       </nav>
     </header>
 
-    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-agua">
+      <main id="contenido-principal" class="reto-main">
       <section class="reto-hero" data-animate="section">
         <div class="reto-hero__content" data-animate-item>
           <span class="reto-hero__badge">Reto global 2</span>
@@ -389,7 +395,8 @@
           <a class="reto-button" href="reto-aire.html">Ir al reto de calidad del aire</a>
         </div>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer>
       <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>

--- a/docs/retos/reto-aire.html
+++ b/docs/retos/reto-aire.html
@@ -41,8 +41,14 @@
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
   </head>
   <body class="reto-page" data-reto="aire" data-barba="wrapper">
-    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header class="reto-header">
+    <div
+      data-barba="container"
+      data-barba-namespace="reto-aire"
+      data-body-class="reto-page"
+      data-reto="aire"
+    >
+      <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+      <header class="reto-header">
       <div class="reto-header__top">
         <a class="reto-header__brand" href="../index.html">
           <svg
@@ -78,7 +84,7 @@
       </nav>
     </header>
 
-    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-aire">
+      <main id="contenido-principal" class="reto-main">
       <section class="reto-hero" data-animate="section">
         <div class="reto-hero__content" data-animate-item>
           <span class="reto-hero__badge">Reto global 3</span>
@@ -375,7 +381,8 @@
           <a class="reto-button" href="reto-biodiversidad.html">Ir al reto de biodiversidad</a>
         </div>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer>
       <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>

--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -41,8 +41,14 @@
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
   </head>
   <body class="reto-page" data-reto="biodiversidad" data-barba="wrapper">
-    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header class="reto-header">
+    <div
+      data-barba="container"
+      data-barba-namespace="reto-biodiversidad"
+      data-body-class="reto-page"
+      data-reto="biodiversidad"
+    >
+      <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+      <header class="reto-header">
       <div class="reto-header__top">
         <a class="reto-header__brand" href="../index.html">
           <svg
@@ -78,7 +84,7 @@
       </nav>
     </header>
 
-    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-biodiversidad">
+      <main id="contenido-principal" class="reto-main">
       <section class="reto-hero" data-animate="section">
         <div class="reto-hero__content" data-animate-item>
           <span class="reto-hero__badge">Reto global 4</span>
@@ -375,7 +381,8 @@
           <a class="reto-button" href="reto-ciudades.html">Ir al reto de ciudades circulares</a>
         </div>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer>
       <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>

--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -41,8 +41,14 @@
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
   </head>
   <body class="reto-page" data-reto="ciudades" data-barba="wrapper">
-    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header class="reto-header">
+    <div
+      data-barba="container"
+      data-barba-namespace="reto-ciudades"
+      data-body-class="reto-page"
+      data-reto="ciudades"
+    >
+      <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+      <header class="reto-header">
       <div class="reto-header__top">
         <a class="reto-header__brand" href="../index.html">
           <svg
@@ -78,7 +84,7 @@
       </nav>
     </header>
 
-    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-ciudades">
+      <main id="contenido-principal" class="reto-main">
       <section class="reto-hero" data-animate="section">
         <div class="reto-hero__content" data-animate-item>
           <span class="reto-hero__badge">Reto global 4</span>
@@ -289,7 +295,8 @@
           <a class="reto-button" href="reto-clima.html">Ir al reto climático</a>
         </div>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer>
       <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>

--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -41,8 +41,14 @@
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
   </head>
   <body class="reto-page" data-reto="clima" data-barba="wrapper">
-    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header class="reto-header">
+    <div
+      data-barba="container"
+      data-barba-namespace="reto-clima"
+      data-body-class="reto-page"
+      data-reto="clima"
+    >
+      <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+      <header class="reto-header">
       <div class="reto-header__top">
         <a class="reto-header__brand" href="../index.html">
           <svg
@@ -78,7 +84,7 @@
       </nav>
     </header>
 
-    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-clima">
+      <main id="contenido-principal" class="reto-main">
       <section class="reto-hero" data-animate="section">
         <div class="reto-hero__content" data-animate-item>
           <span class="reto-hero__badge">Reto global 1</span>
@@ -372,7 +378,8 @@
           <a class="reto-button" href="reto-energia.html">Ir al reto de transición energética</a>
         </div>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer>
       <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>

--- a/docs/retos/reto-energia.html
+++ b/docs/retos/reto-energia.html
@@ -41,8 +41,14 @@
     <script src="https://cdn.jsdelivr.net/npm/@barba/core@2.9.7/dist/barba.umd.js" defer></script>
   </head>
   <body class="reto-page" data-reto="energia" data-barba="wrapper">
-    <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
-    <header class="reto-header">
+    <div
+      data-barba="container"
+      data-barba-namespace="reto-energia"
+      data-body-class="reto-page"
+      data-reto="energia"
+    >
+      <a class="reto-skip-link" href="#contenido-principal">Saltar al contenido principal</a>
+      <header class="reto-header">
       <div class="reto-header__top">
         <a class="reto-header__brand" href="../index.html">
           <svg
@@ -78,7 +84,7 @@
       </nav>
     </header>
 
-    <main id="contenido-principal" class="reto-main" data-barba="container" data-barba-namespace="reto-energia">
+      <main id="contenido-principal" class="reto-main">
       <section class="reto-hero" data-animate="section">
         <div class="reto-hero__content" data-animate-item>
           <span class="reto-hero__badge">Reto global 1</span>
@@ -239,7 +245,8 @@
           <a class="reto-button" href="reto-agua.html">Ir al reto de gestión del agua</a>
         </div>
       </section>
-    </main>
+      </main>
+    </div>
 
     <footer>
       <p>Recurso educativo abierto del programa “Sostenibilidad 2030”.</p>

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -44,6 +44,31 @@
     }
   }
 
+  function syncBodyAttributes(container) {
+    if (!container) {
+      return;
+    }
+
+    const body = document.body;
+    const targetClassName = container.dataset.bodyClass || '';
+
+    body.className = targetClassName;
+
+    Object.keys(body.dataset).forEach((key) => {
+      if (key !== 'barba') {
+        delete body.dataset[key];
+      }
+    });
+
+    Object.keys(container.dataset).forEach((key) => {
+      if (key === 'bodyClass') {
+        return;
+      }
+
+      body.dataset[key] = container.dataset[key];
+    });
+  }
+
   function ensureLeafletStyle() {
     if (assetState.leafletStyleLoaded) {
       return Promise.resolve();
@@ -1108,6 +1133,7 @@
 
   function initBarba() {
     if (!window.barba) {
+      syncBodyAttributes(document.querySelector('[data-barba="container"]'));
       initPage();
       focusMain(true);
       return;
@@ -1119,12 +1145,16 @@
       teardownPage();
     });
 
-    window.barba.hooks.afterEnter(() => {
+    window.barba.hooks.afterEnter((data) => {
+      const nextContainer = data && data.next && data.next.container;
+      syncBodyAttributes(nextContainer);
       initPage();
       focusMain();
     });
 
-    window.barba.hooks.once(() => {
+    window.barba.hooks.once((data) => {
+      const nextContainer = data && data.next && data.next.container;
+      syncBodyAttributes(nextContainer);
       initPage();
       focusMain(true);
     });


### PR DESCRIPTION
## Summary
- wrap the skip link, header, and main content in a shared Barba container on the home and reto pages and expose body metadata on that node
- ensure reto containers provide the body class and reto identifier so the wrapper can restore per-page styling
- update the Barba lifecycle hooks to copy the new container data onto document.body before initializing each page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e82c3fba5c8329a4e080b473a5893b