### PR TITLE
Handle hash scrolling after barba page init

### DIFF
--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -1141,6 +1141,29 @@
 
     const overlay = createOverlay();
 
+    function scrollToHash(hash) {
+      if (!hash || hash === '#') {
+        return;
+      }
+
+      let target;
+      try {
+        target = document.querySelector(hash);
+      } catch (error) {
+        return;
+      }
+
+      if (!target) {
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        target.scrollIntoView({
+          behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+        });
+      });
+    }
+
     window.barba.hooks.beforeLeave(() => {
       teardownPage();
     });
@@ -1149,6 +1172,8 @@
       const nextContainer = data && data.next && data.next.container;
       syncBodyAttributes(nextContainer);
       initPage();
+      const hash = (data && data.next && data.next.url && data.next.url.hash) || window.location.hash;
+      scrollToHash(hash);
       focusMain();
     });
 
@@ -1156,6 +1181,8 @@
       const nextContainer = data && data.next && data.next.container;
       syncBodyAttributes(nextContainer);
       initPage();
+      const hash = (data && data.next && data.next.url && data.next.url.hash) || window.location.hash;
+      scrollToHash(hash);
       focusMain(true);
     });
 


### PR DESCRIPTION
## Summary
- add helper to scroll to hash anchors after initializing each page
- trigger smooth or instant scrolling based on reduced motion preference in barba hooks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e82e3387a08329a4d466400415f1e8