### PR TITLE
Ensure hero imagery fallback resolves correctly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -119,12 +119,7 @@
 
       <main id="contenido-principal">
       <section id="hero" aria-labelledby="hero-heading">
-        <div
-          class="hero-media"
-          aria-hidden="true"
-          data-hero-container
-          style="--hero-fallback-image: url('assets/img/hero-aurora.svg');"
-        >
+        <div class="hero-media" aria-hidden="true" data-hero-container data-hero-fallback="assets/img/hero-aurora.svg">
           <picture class="hero-media__image" data-lqip data-lqip-src="assets/img/hero-aurora.svg">
             <source type="image/svg+xml" srcset="assets/img/hero-aurora.svg" />
             <img


### PR DESCRIPTION
## Summary
- stop shipping a hard-coded hero fallback URL that triggered 404s by moving it to a data attribute
- add hero media hydration in app.js to normalise URLs, set low-quality placeholders and flag when the hero image has loaded
- keep the new hero handling hooked into the existing page init lifecycle so transitions remain stable

## Testing
- browser_container.run_playwright_script (index ➜ reto ➜ volver)

------
https://chatgpt.com/codex/tasks/task_b_68e8fe65e9448329866ff6f350bb2f8e