### PR TITLE
Fix hero fallback asset resolution across SPA navigation

### DIFF
--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -795,7 +795,15 @@
           container.style.backgroundImage = cssValue;
         }
 
-        if (img && !img.dataset.fallbackSrc) {
+        if (container.hasAttribute && container.hasAttribute('data-hero-fallback')) {
+          container.dataset.heroFallback = absolute;
+        }
+
+        if (picture && picture.dataset && picture.hasAttribute && picture.hasAttribute('data-hero-fallback')) {
+          picture.dataset.heroFallback = absolute;
+        }
+
+        if (img) {
           img.dataset.fallbackSrc = absolute;
         }
       };
@@ -818,6 +826,14 @@
       if (lqipSource) {
         const absoluteLqip = toAbsoluteUrl(lqipSource);
         container.style.setProperty('--lqip', `url("${absoluteLqip}") center/cover no-repeat`);
+
+        if (container.hasAttribute && container.hasAttribute('data-lqip-src')) {
+          container.dataset.lqipSrc = absoluteLqip;
+        }
+
+        if (picture && picture.dataset && picture.hasAttribute && picture.hasAttribute('data-lqip-src')) {
+          picture.dataset.lqipSrc = absoluteLqip;
+        }
       }
 
       const markLoaded = () => {


### PR DESCRIPTION
## Summary
- normalise hero fallback and LQIP sources to absolute URLs so they persist after Barba transitions
- prevent missing hero imagery and 404 asset requests when navigating between home and reto pages

## Testing
- Playwright navigation smoke test across home → reto → home

------
https://chatgpt.com/codex/tasks/task_b_68e905e3992c8329a293d6736d6ac13f