### PR TITLE
Fix KPI counter initialization when CountUp loads from CDN

### DIFF
--- a/docs/scripts/animations.js
+++ b/docs/scripts/animations.js
@@ -14,6 +14,20 @@
   const splitCache = new WeakSet();
   const configCache = new Map();
 
+  function resolveCountUpConstructor() {
+    const namespaces = [window.CountUp, window.countUp];
+    for (const namespace of namespaces) {
+      if (!namespace) continue;
+      if (typeof namespace === 'function') {
+        return namespace;
+      }
+      if (typeof namespace.CountUp === 'function') {
+        return namespace.CountUp;
+      }
+    }
+    return null;
+  }
+
   async function loadJsonConfig(path) {
     if (!path) return null;
     const cacheKey = path;
@@ -492,8 +506,6 @@
     const kpis = document.querySelectorAll('.kpi');
     if (!kpis.length) return;
 
-    const CountUp = window.CountUp && window.CountUp.CountUp ? window.CountUp.CountUp : window.CountUp;
-
     const observer = registerObserver(
       new IntersectionObserver((entries, obs) => {
         entries.forEach((entry) => {
@@ -502,6 +514,7 @@
           const valueEl = element.querySelector('.kpi-value');
           const fallbackText = valueEl ? valueEl.textContent : '0';
           const target = Number.parseFloat(element.dataset.target || fallbackText || '0');
+          const CountUp = resolveCountUpConstructor();
 
           if (!valueEl) {
             obs.unobserve(element);

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -151,9 +151,17 @@
     return assetState.leafletPromise;
   }
 
+  function normalizeCountUpGlobal() {
+    if (typeof window.CountUp === 'undefined' && typeof window.countUp !== 'undefined') {
+      window.CountUp = window.countUp;
+    }
+    return window.CountUp;
+  }
+
   function ensureCountUp() {
-    if (typeof window.CountUp !== 'undefined') {
-      return Promise.resolve(window.CountUp);
+    const existingGlobal = normalizeCountUpGlobal();
+    if (typeof existingGlobal !== 'undefined') {
+      return Promise.resolve(existingGlobal);
     }
 
     if (assetState.countUpPromise) {
@@ -165,7 +173,8 @@
       assetState.countUpPromise = new Promise((resolve, reject) => {
         existing.addEventListener('load', () => {
           assetState.countUpPromise = null;
-          resolve(window.CountUp);
+          const global = normalizeCountUpGlobal();
+          resolve(global);
         }, { once: true });
         existing.addEventListener('error', () => {
           assetState.countUpPromise = null;
@@ -184,7 +193,8 @@
       script.dataset.countupScript = 'true';
       script.addEventListener('load', () => {
         assetState.countUpPromise = null;
-        resolve(window.CountUp);
+        const global = normalizeCountUpGlobal();
+        resolve(global);
       });
       script.addEventListener('error', () => {
         assetState.countUpPromise = null;


### PR DESCRIPTION
## Summary
- normalize the CountUp global when the CDN exposes the library under `window.countUp`
- re-resolve the CountUp constructor when KPI cards intersect so lazy loading still animates values

## Testing
- Manual check: KPI counters update after scrolling through the home page

------
https://chatgpt.com/codex/tasks/task_b_68e92e4b32c483298a97b3cbb879df3f