### PR TITLE
Fix mobile navigation fallback and reto styles

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -86,7 +86,7 @@
           </svg>
           <span>Sostenibilidad 2030</span>
         </a>
-        <div class="nav-panel" id="menu-principal" data-open="true">
+        <div class="nav-panel" id="menu-principal" data-open="false">
           <ul class="nav-links">
             <li><a href="#hero">Inicio</a></li>
             <li><a href="#retos">Los 4 retos</a></li>

--- a/docs/retos/reto-agua.html
+++ b/docs/retos/reto-agua.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -35,6 +35,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../styles/main.css" />
+    <link rel="stylesheet" href="../styles/icons.css" />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>

--- a/docs/retos/reto-aire.html
+++ b/docs/retos/reto-aire.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -35,6 +35,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../styles/main.css" />
+    <link rel="stylesheet" href="../styles/icons.css" />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>

--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -35,6 +35,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../styles/main.css" />
+    <link rel="stylesheet" href="../styles/icons.css" />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>

--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -35,6 +35,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../styles/main.css" />
+    <link rel="stylesheet" href="../styles/icons.css" />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>

--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -35,6 +35,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../styles/main.css" />
+    <link rel="stylesheet" href="../styles/icons.css" />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>

--- a/docs/retos/reto-energia.html
+++ b/docs/retos/reto-energia.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
-<html lang="es" data-theme="light">
+<html lang="es" data-theme="light" class="no-js">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Reto Energía | Sostenibilidad 2030</title>
-    <meta
-      name="description"
-      content="Cooperativas solares comunitarias en Atacama que proveen energía limpia y asequible a hogares del norte de Chile."
-    />
+    <meta name="description" content="Cooperativas solares comunitarias en Atacama que proveen energía limpia y asequible a hogares del norte de Chile." />
     <meta name="keywords" content="energía solar, Atacama, transición energética, cooperativas" />
     <meta name="author" content="Equipo Educativo Sostenibilidad 2030" />
     <meta property="og:type" content="website" />
@@ -35,6 +32,8 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Playfair+Display:wght@600&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="../styles/main.css" />
+    <link rel="stylesheet" href="../styles/icons.css" />
     <link rel="stylesheet" href="../styles/retos.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js" defer></script>

--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -1,4 +1,10 @@
 (function () {
+  const docElement = document.documentElement;
+  if (docElement.classList.contains('no-js')) {
+    docElement.classList.remove('no-js');
+  }
+  docElement.classList.add('js-enabled');
+
   const THEME_STORAGE_KEY = 'sostenibilidad-theme';
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
   const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -1375,6 +1375,12 @@ footer small {
     z-index: var(--z-overlay);
   }
 
+  html.no-js .nav-panel {
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   .nav-panel[data-open="true"] {
     transform: translateX(0);
     opacity: 1;
@@ -1393,6 +1399,10 @@ footer small {
 
   .nav-toggle {
     display: inline-flex;
+  }
+
+  html.no-js .nav-toggle {
+    display: none;
   }
 
   .hero-content {


### PR DESCRIPTION
## Summary
- prevent the mobile menu from flashing open by default while keeping a usable fallback when JavaScript is disabled
- expose the shared base/icon styles and correct the energy reto meta description so detail pages display assets consistently
- toggle a no-js class in the bootstrap script to coordinate CSS behaviour when JavaScript is available

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68e947f483488329ab59e1fd9f4a1c2e