### PR TITLE
Ensure reto mini maps load Leaflet correctly

### DIFF
--- a/docs/scripts/app.js
+++ b/docs/scripts/app.js
@@ -1132,6 +1132,8 @@
     parseAndRenderRetos();
     initHoverCards();
 
+    const mapTargets = document.querySelectorAll('#mapa-global, [id^="map-"]');
+
     if (window.AnimationManager && typeof window.AnimationManager.init === 'function') {
       window.AnimationManager.init();
     }
@@ -1141,6 +1143,13 @@
     }
 
     observeMapsForDependencies();
+
+    if (
+      mapTargets.length &&
+      (typeof window.L === 'undefined' || typeof window.L.map !== 'function')
+    ) {
+      loadMapDependencies().catch(() => {});
+    }
 
     if (window.feather && typeof window.feather.replace === 'function') {
       window.feather.replace();

--- a/docs/scripts/map.js
+++ b/docs/scripts/map.js
@@ -260,7 +260,8 @@
       ensureLazyImages(container.parentElement);
 
       if (!L) {
-        container.innerHTML = '<p class="map-fallback">Activa la vista de mapa para explorar la ubicación.</p>';
+        container.innerHTML =
+          '<p class="map-fallback">Cargando mapa interactivo…</p>';
         return;
       }
 

--- a/docs/styles/retos.css
+++ b/docs/styles/retos.css
@@ -767,6 +767,16 @@ html[data-theme="dark"] .reto-page {
   box-shadow: var(--reto-shadow-soft);
 }
 
+.reto-section [id^="map-"] {
+  display: block;
+  width: 100%;
+  min-height: clamp(280px, 45vw, 420px);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--reto-border) 80%, transparent);
+  box-shadow: var(--reto-shadow-soft);
+}
+
 .reto-cta {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- eagerly request Leaflet assets when any map container is present
- update mini map fallback message and hydrate maps once dependencies resolve
- align reto detail map styling so Leaflet keeps the expected height

## Testing
- python -m http.server 8000 --directory docs

------
https://chatgpt.com/codex/tasks/task_b_68e94eedabd88329a23a0a595e41c582