### PR TITLE
Fix mobile nav overlay height

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -1355,6 +1355,7 @@ footer small {
     top: var(--nav-height);
     right: 0;
     bottom: 0;
+    height: calc(100vh - var(--nav-height));
     width: min(320px, 82vw);
     max-width: 100%;
     max-height: calc(100vh - var(--nav-height));


### PR DESCRIPTION
## Summary
- ensure the mobile navigation drawer spans the full viewport height so the menu covers content when opened

## Testing
- playwright script to open the mobile nav and confirm the panel height matches the viewport

------
https://chatgpt.com/codex/tasks/task_b_68e982bf4b04832995c4365bcfcd50e0