### PR TITLE
Mejora la navegación y la experiencia de retos

### DIFF
--- a/docs/assets/img/mapa-placeholder.svg
+++ b/docs/assets/img/mapa-placeholder.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="360" viewBox="0 0 480 360" role="img" aria-labelledby="title desc">
+  <title id="title">Ilustración de mapa en espera</title>
+  <desc id="desc">Mapa abstracto con marcadores para invitar a seleccionar un reto.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.85" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#cbd5f5" stop-opacity="0.85" />
+    </linearGradient>
+    <linearGradient id="pin" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <filter id="glow" x="-15%" y="-15%" width="130%" height="130%">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="480" height="360" rx="36" fill="url(#bg)" />
+  <g fill="#ffffff" opacity="0.18">
+    <path d="M52 96h144c12 0 18 6 24 12l48 48c8 8 16 12 28 12h132" stroke="#fff" stroke-opacity="0.15" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <path d="M72 280h92c10 0 18-6 26-14l32-34c8-8 16-12 28-12h112" stroke="#fff" stroke-opacity="0.12" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  </g>
+  <g transform="translate(64 64)">
+    <rect width="180" height="130" rx="20" fill="url(#panel)" opacity="0.9" />
+    <path d="M32 76l28-32 28 32 24-20 24 20v20H32z" fill="#1d4ed8" opacity="0.18" />
+    <rect x="32" y="28" width="116" height="12" rx="6" fill="#0f172a" opacity="0.25" />
+    <rect x="32" y="48" width="92" height="10" rx="5" fill="#0f172a" opacity="0.18" />
+    <rect x="32" y="100" width="84" height="10" rx="5" fill="#0f172a" opacity="0.18" />
+  </g>
+  <g transform="translate(290 118)">
+    <circle cx="44" cy="44" r="44" fill="#1e293b" opacity="0.25" />
+    <path d="M44 4c18 0 34 14 34 34 0 24-34 54-34 54S10 62 10 38C10 18 26 4 44 4z" fill="url(#pin)" />
+    <circle cx="44" cy="38" r="10" fill="#fff" opacity="0.85" />
+  </g>
+  <g transform="translate(110 220)" filter="url(#glow)" opacity="0.9">
+    <path d="M28 0c16 0 28 12 28 28s-28 52-28 52S0 44 0 28 12 0 28 0z" fill="#facc15" />
+    <circle cx="28" cy="26" r="9" fill="#fff" opacity="0.9" />
+  </g>
+  <g opacity="0.35" stroke="#ffffff" stroke-width="2" stroke-dasharray="10 12" fill="none">
+    <circle cx="80" cy="40" r="26" />
+    <circle cx="400" cy="300" r="34" />
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,59 +62,61 @@
     <div data-barba="container" data-barba-namespace="home" data-body-class="">
       <a class="skip-link" href="#contenido-principal">Saltar al contenido principal</a>
 
-      <header>
-      <nav aria-label="Menú principal">
-        <a class="brand" href="#hero">
-          <span class="sr-only">Ir al inicio</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 64 64"
-            role="img"
-            aria-labelledby="logo-title logo-desc"
-          >
-            <title id="logo-title">Sostenibilidad 2030</title>
-            <desc id="logo-desc">Logotipo circular con hoja y ondas que representan equilibrio ambiental</desc>
-            <circle cx="32" cy="32" r="30" fill="none" stroke="currentColor" stroke-width="3" />
-            <path
-              d="M18 36c10-4 16-12 18-24 8 8 12 20 6 32-4 8-12 12-20 10"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="3"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            ></path>
-          </svg>
-          <span>Sostenibilidad 2030</span>
-        </a>
-        <div class="nav-panel" id="menu-principal" data-open="false">
-          <ul class="nav-links">
-            <li><a href="#hero">Inicio</a></li>
-            <li><a href="#retos">Los 4 retos</a></li>
-            <li><a href="#mapa-global">Mapa global</a></li>
-            <li><a href="#footer">Recursos</a></li>
-          </ul>
+      <header class="site-header" data-animate="section">
+        <div class="site-header__inner">
+          <a class="brand site-header__brand" href="#hero">
+            <span class="sr-only">Ir al inicio</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 64 64"
+              role="img"
+              aria-labelledby="logo-title logo-desc"
+            >
+              <title id="logo-title">Sostenibilidad 2030</title>
+              <desc id="logo-desc">Logotipo circular con hoja y ondas que representan equilibrio ambiental</desc>
+              <circle cx="32" cy="32" r="30" fill="none" stroke="currentColor" stroke-width="3" />
+              <path
+                d="M18 36c10-4 16-12 18-24 8 8 12 20 6 32-4 8-12 12-20 10"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></path>
+            </svg>
+            <span>Sostenibilidad 2030</span>
+          </a>
+          <nav class="site-header__nav" aria-label="Menú principal">
+            <div class="nav-panel" id="menu-principal" data-open="false">
+              <ul class="nav-links">
+                <li><a href="#hero">Inicio</a></li>
+                <li><a href="#retos">Los 4 retos</a></li>
+                <li><a href="#mapa-global">Mapa global</a></li>
+                <li><a href="#footer">Recursos</a></li>
+              </ul>
+            </div>
+          </nav>
+          <div class="nav-actions">
+            <button class="theme-toggle" type="button" aria-pressed="false">
+              <span aria-hidden="true" data-feather="moon"></span>
+              <span>Modo</span>
+            </button>
+            <button
+              class="nav-toggle"
+              type="button"
+              aria-controls="menu-principal"
+              aria-expanded="false"
+              aria-label="Abrir menú"
+            >
+              <span class="nav-toggle__icon" aria-hidden="true">
+                <span></span>
+                <span></span>
+                <span></span>
+              </span>
+              <span class="nav-toggle__label">Menú</span>
+            </button>
+          </div>
         </div>
-        <div class="nav-actions">
-          <button class="theme-toggle" type="button" aria-pressed="false">
-            <span aria-hidden="true" data-feather="moon"></span>
-            <span>Modo</span>
-          </button>
-          <button
-            class="nav-toggle"
-            type="button"
-            aria-controls="menu-principal"
-            aria-expanded="false"
-            aria-label="Abrir menú"
-          >
-            <span class="nav-toggle__icon" aria-hidden="true">
-              <span></span>
-              <span></span>
-              <span></span>
-            </span>
-            <span class="nav-toggle__label">Menú</span>
-          </button>
-        </div>
-      </nav>
       </header>
 
       <main id="contenido-principal">
@@ -359,19 +361,25 @@
         <div class="map-container" role="presentation">
           <div id="map" role="application" aria-label="Mapa de proyectos de sostenibilidad"></div>
         </div>
-        <aside class="map-panel" aria-live="polite" aria-atomic="true">
+        <aside
+          class="map-panel"
+          aria-live="polite"
+          aria-atomic="true"
+          data-state="idle"
+        >
           <h2 id="mapa-global-heading">Mapa global de iniciativas</h2>
           <p>
             Selecciona un marcador para descubrir datos, historias y recursos de aprendizaje sobre cada reto.
           </p>
-          <div class="map-details">
+          <div class="map-details" data-placeholder-image="assets/img/mapa-placeholder.svg" data-state="idle">
             <h3 data-map-title>Selecciona un reto</h3>
-            <p data-map-summary>Los datos aparecerán aquí cuando interactúes con el mapa.</p>
+            <p data-map-summary>Interactúa con el mapa para conocer los datos clave de cada caso.</p>
             <img
               data-map-image
               alt="Vista ilustrativa del reto seleccionado en el mapa global"
               hidden
               loading="lazy"
+              data-placeholder-image="assets/img/mapa-placeholder.svg"
             />
             <a data-map-link href="#" target="_blank" rel="noopener" hidden>Explorar recurso</a>
           </div>

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -358,23 +358,44 @@ strong {
 }
 
 /* ===== Navegación fija =================================================== */
-header {
-  position: fixed;
-  inset: 0 0 auto 0;
-  height: var(--nav-height);
+.site-header {
+  position: sticky;
+  top: 0;
   z-index: var(--z-nav);
   backdrop-filter: blur(18px);
-  background: var(--color-surface-alt);
+  background: color-mix(in srgb, var(--color-surface-alt) 85%, transparent);
   border-bottom: 1px solid var(--color-border);
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.28);
+  isolation: isolate;
 }
 
-nav {
-  height: 100%;
+.site-header::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.18), transparent 65%),
+    linear-gradient(120deg, rgba(59, 130, 246, 0.18), transparent 55%);
+  opacity: 0.65;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.site-header__inner {
+  height: var(--nav-height);
+  max-width: min(1200px, 94vw);
+  margin-inline: auto;
+  padding: 0 clamp(1rem, 3vw, 2rem);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 2.5rem);
+}
+
+.site-header__nav {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: clamp(1rem, 3vw, 2.5rem);
-  padding: 0 clamp(1rem, 3vw, 2rem);
+  justify-content: center;
+  height: 100%;
 }
 
 .nav-panel {
@@ -382,6 +403,7 @@ nav {
   display: flex;
   align-items: center;
   justify-content: center;
+  height: 100%;
   flex: 1 1 auto;
 }
 
@@ -392,11 +414,17 @@ nav {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+.site-header__brand span {
+  letter-spacing: 0.12em;
 }
 
 .brand svg {
   width: 42px;
   height: 42px;
+  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.35));
 }
 
 .nav-links {
@@ -411,10 +439,12 @@ nav {
   position: relative;
   font-weight: 600;
   padding-block: var(--space-2xs);
+  color: color-mix(in srgb, var(--color-text) 86%, var(--color-muted) 14%);
+  transition: color var(--transition-base);
 }
 
 .nav-links a::after {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
   bottom: -0.4rem;
@@ -430,7 +460,7 @@ nav {
   transform: scaleX(1);
 }
 
-.nav-links a:is([aria-current="page"], .is-active) {
+.nav-links a:is(:hover, :focus-visible, [aria-current="page"], .is-active) {
   color: var(--color-accent-strong);
 }
 
@@ -859,7 +889,8 @@ body.has-mobile-nav-open {
   pointer-events: none;
 }
 
-.map-panel[data-active-reto] .map-details::before {
+.map-panel[data-active-reto] .map-details::before,
+.map-panel[data-state="active"] .map-details::before {
   opacity: 1;
 }
 
@@ -901,7 +932,27 @@ body.has-mobile-nav-open {
   box-shadow: var(--shadow-md);
 }
 
-.map-panel[data-active-reto] .reto-card.is-active {
+.map-panel[data-state="idle"] .map-details {
+  background: color-mix(in srgb, var(--color-surface-alt) 10%, transparent);
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--color-border) 55%, transparent);
+}
+
+.map-panel[data-state="idle"] .map-details h3 {
+  color: color-mix(in srgb, var(--color-text) 80%, var(--color-muted) 20%);
+}
+
+.map-panel[data-state="idle"] .map-details p {
+  color: color-mix(in srgb, var(--color-muted) 85%, rgba(255, 255, 255, 0.65) 15%);
+}
+
+.map-panel[data-state="idle"] .map-details img[data-state="placeholder"] {
+  opacity: 0.85;
+  filter: saturate(1.05);
+}
+
+.map-panel[data-active-reto] .reto-card.is-active,
+.map-panel[data-state="active"] .reto-card.is-active {
   box-shadow: var(--shadow-md);
 }
 
@@ -1342,12 +1393,17 @@ footer small {
     scroll-snap-type: none;
   }
 
-  header {
+  .site-header {
     backdrop-filter: blur(20px);
   }
 
-  nav {
+  .site-header__inner {
     gap: var(--space-lg);
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .site-header__nav {
+    justify-content: flex-end;
   }
 
   .nav-panel {

--- a/docs/styles/retos.css
+++ b/docs/styles/retos.css
@@ -23,7 +23,7 @@
   --reto-radius-md: 1.25rem;
   --reto-radius-lg: 2.25rem;
   --reto-radius-pill: 999px;
-  --reto-max-width: min(1100px, 92vw);
+  --reto-max-width: min(1180px, 94vw);
   --reto-hero-height: clamp(520px, 78vh, 720px);
   --reto-ornament: rgba(255, 255, 255, 0.55);
 
@@ -148,11 +148,26 @@ html[data-theme="dark"] .reto-page {
   top: 0;
   z-index: 900;
   backdrop-filter: blur(18px);
-  background-color: rgba(255, 255, 255, 0.92);
-  background: color-mix(in srgb, var(--reto-surface) 80%, transparent);
-  box-shadow: var(--reto-nav-shadow);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  background: color-mix(in srgb, var(--reto-surface) 75%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--reto-border) 70%, transparent);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
   isolation: isolate;
+  overflow: hidden;
+}
+
+.reto-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at top right,
+      color-mix(in srgb, var(--reto-accent) 45%, transparent) 0%,
+      transparent 65%
+    ),
+    linear-gradient(120deg, color-mix(in srgb, var(--reto-accent-soft) 65%, transparent), transparent 70%);
+  opacity: 0.7;
+  pointer-events: none;
+  z-index: -1;
 }
 
 .reto-header__top,
@@ -183,12 +198,17 @@ html[data-theme="dark"] .reto-page {
   gap: 0.65rem;
   text-decoration: none;
   font-weight: 600;
+  transition: transform 180ms ease;
 }
 
 .reto-header__brand svg {
   width: 28px;
   height: 28px;
   color: var(--reto-accent-strong);
+}
+
+.reto-header__brand:is(:hover, :focus-visible) {
+  transform: translateY(-1px);
 }
 
 .reto-header__meta {
@@ -198,6 +218,18 @@ html[data-theme="dark"] .reto-page {
   align-items: center;
   font-size: 0.95rem;
   color: var(--reto-muted);
+}
+
+.reto-header__meta a {
+  color: var(--reto-accent-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.reto-header__meta a:is(:hover, :focus-visible) {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0.2em;
 }
 
 .reto-pill {
@@ -217,13 +249,15 @@ html[data-theme="dark"] .reto-page {
 .reto-breadcrumb {
   margin: 0;
   padding: 0.75rem clamp(1.75rem, 5vw, 4.25rem);
-  background-color: rgba(255, 255, 255, 0.58);
-  background: color-mix(in srgb, var(--reto-accent-soft) 65%, transparent);
+  background: color-mix(in srgb, var(--reto-surface) 78%, transparent);
   list-style: none;
   display: flex;
   gap: 0.65rem;
   flex-wrap: wrap;
   font-size: 0.95rem;
+  border-top: 1px solid color-mix(in srgb, var(--reto-border) 55%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--reto-border) 35%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
 }
 
 .reto-breadcrumb li {
@@ -263,8 +297,14 @@ html[data-theme="dark"] .reto-page {
   align-items: center;
   gap: clamp(2rem, 6vw, 3rem);
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  padding: clamp(3rem, 6vw, 5rem) clamp(1.75rem, 7vw, 6rem);
+  padding: clamp(3rem, 6vw, 5rem) clamp(2rem, 7vw, 5.5rem);
   overflow: hidden;
+  max-width: var(--reto-max-width);
+  margin-inline: auto;
+  border-radius: var(--reto-radius-lg);
+  background: color-mix(in srgb, var(--reto-surface) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--reto-border) 65%, transparent);
+  box-shadow: var(--reto-shadow-strong);
 }
 
 .reto-hero::before {
@@ -274,7 +314,7 @@ html[data-theme="dark"] .reto-page {
   background-image: var(--reto-hero-image);
   background-size: cover;
   background-position: center;
-  opacity: 0.18;
+  opacity: 0.22;
   mix-blend-mode: multiply;
   z-index: 0;
 }
@@ -283,7 +323,7 @@ html[data-theme="dark"] .reto-page {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(130deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0));
+  background: linear-gradient(130deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
   z-index: 0;
 }
 
@@ -293,6 +333,12 @@ html[data-theme="dark"] .reto-page {
   max-width: 620px;
   display: grid;
   gap: 1.1rem;
+  padding: clamp(1.75rem, 4vw, 2.6rem);
+  border-radius: var(--reto-radius-lg);
+  background: color-mix(in srgb, var(--reto-surface-strong) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--reto-border) 70%, transparent);
+  box-shadow: var(--reto-shadow-soft);
+  backdrop-filter: blur(12px);
 }
 
 .reto-hero__badge {
@@ -322,6 +368,7 @@ html[data-theme="dark"] .reto-page {
 .reto-hero__summary {
   font-size: 1.05rem;
   color: var(--reto-muted);
+  max-width: 58ch;
 }
 
 .reto-hero__actions {
@@ -367,6 +414,7 @@ html[data-theme="dark"] .reto-page {
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   margin-top: 1.5rem;
+  padding-top: 0.5rem;
 }
 
 .reto-stat {
@@ -374,9 +422,10 @@ html[data-theme="dark"] .reto-page {
   padding: 1.1rem;
   border-radius: 1rem;
   background-color: rgba(255, 255, 255, 0.9);
-  background: color-mix(in srgb, var(--reto-surface) 85%, transparent);
-  border: 1px solid var(--reto-border);
-  box-shadow: 0 20px 40px -28px rgba(15, 23, 42, 0.38);
+  background: color-mix(in srgb, var(--reto-surface) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--reto-border) 70%, transparent);
+  box-shadow: 0 22px 45px -26px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(10px);
   overflow: hidden;
 }
 
@@ -410,15 +459,17 @@ html[data-theme="dark"] .reto-page {
   align-self: stretch;
   display: grid;
   place-items: center;
+  padding: clamp(1.25rem, 3vw, 2rem);
 }
 
 .reto-hero__visual {
   position: relative;
-  width: min(420px, 90%);
+  width: min(480px, 100%);
   border-radius: var(--reto-radius-lg);
   overflow: hidden;
   box-shadow: var(--reto-shadow-strong);
-  background: color-mix(in srgb, rgba(255, 255, 255, 0.96) 65%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.96) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--reto-border) 60%, transparent);
   animation: floatY 8s ease-in-out infinite;
 }
 
@@ -442,9 +493,10 @@ html[data-theme="dark"] .reto-page {
   width: clamp(120px, 24vw, 180px);
   aspect-ratio: 1;
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), transparent 65%);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), transparent 65%),
+    linear-gradient(180deg, color-mix(in srgb, var(--reto-accent) 40%, transparent), transparent 70%);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
-  opacity: 0.7;
+  opacity: 0.65;
   backdrop-filter: blur(4px);
   animation: floatX 9s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
- Reorganize the home navigation header with a translucent container and updated styles
- Improve the global map panel with placeholder artwork, better empty state copy, and resilient scripting
- Refresh reto detail pages with broader layouts, glassmorphism hero cards, and refined typography

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68e9996e939883299ace3af835a471eb