### PR TITLE
Add open-license photo galleries to reto pages

### DIFF
--- a/docs/retos/reto-agua.html
+++ b/docs/retos/reto-agua.html
@@ -275,6 +275,45 @@
             />
             <figcaption>Cooperativas femeninas administran parte del campo solar y reciben capacitación técnica.</figcaption>
           </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:A_Community_Water_Project.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/e/e9/A_Community_Water_Project.jpg"
+                alt="Vecinos posan junto a un tanque elevado recién instalado"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Redes comunitarias gestionan infraestructura hídrica compartida. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:A_Community_Water_Project.jpg" target="_blank" rel="noopener"
+                >Cpraise (CC0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a
+              href="https://commons.wikimedia.org/wiki/File:Jangali_Ram_draws_water_from_a_in_Ganespur_Community_of_Bastipur_NEWAH_WASH_project_Siraha,_Udayapur_District,_Nepal_(10705740874).jpg"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/1/1e/Jangali_Ram_draws_water_from_a_in_Ganespur_Community_of_Bastipur_NEWAH_WASH_project_Siraha%2C_Udayapur_District%2C_Nepal_%2810705740874%29.jpg"
+                alt="Hombre llena recipientes en un punto de agua comunitario"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Modelos WASH aseguran acceso equitativo y mantenimiento local. Foto:
+              <a
+                href="https://commons.wikimedia.org/wiki/File:Jangali_Ram_draws_water_from_a_in_Ganespur_Community_of_Bastipur_NEWAH_WASH_project_Siraha,_Udayapur_District,_Nepal_(10705740874).jpg"
+                target="_blank"
+                rel="noopener"
+                >Department of Foreign Affairs and Trade (CC BY 2.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
         </div>
       </section>
 

--- a/docs/retos/reto-aire.html
+++ b/docs/retos/reto-aire.html
@@ -267,6 +267,41 @@
             />
             <figcaption>Microhubs logísticos realizan la última milla con bicicletas eléctricas de carga.</figcaption>
           </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:Air_Quality_Monitoring_Station.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/8/83/Air_Quality_Monitoring_Station.jpg"
+                alt="Cabina de monitoreo de calidad del aire instalada junto a una avenida"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Estaciones automáticas registran contaminantes en tiempo real. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:Air_Quality_Monitoring_Station.jpg" target="_blank" rel="noopener"
+                >Michael Coghlan (CC BY-SA 2.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:Air_monitoring_station_-_Morwell_South_-_Victoria.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/3/30/Air_monitoring_station_-_Morwell_South_-_Victoria.jpg"
+                alt="Personal técnico revisa sensores en una estación de aire exterior"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Equipos técnicos comunitarios se capacitan para mantener sensores. Foto:
+              <a
+                href="https://commons.wikimedia.org/wiki/File:Air_monitoring_station_-_Morwell_South_-_Victoria.jpg"
+                target="_blank"
+                rel="noopener"
+                >Environment Protection Authority Victoria (CC BY 4.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
         </div>
       </section>
 

--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -266,6 +266,45 @@
             />
             <figcaption>Jóvenes investigadores combinan tecnología y conocimiento tradicional en el monitoreo.</figcaption>
           </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:Amazon_Manaus_forest.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/4/4b/Amazon_Manaus_forest.jpg"
+                alt="Canopia verde del bosque amazónico cerca de Manaos"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Bosques continuos protegidos por las comunidades mantienen la conectividad ecológica. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:Amazon_Manaus_forest.jpg" target="_blank" rel="noopener"
+                >Phil P Harris (CC BY-SA 2.5) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a
+              href="https://commons.wikimedia.org/wiki/File:Achuar_community_members_working_cement_(5847200298).jpg"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/2/2f/Achuar_community_members_working_cement_%285847200298%29.jpg"
+                alt="Integrantes de la comunidad Achuar mezclan materiales para infraestructura"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Talleres comunitarios refuerzan capacidades para infraestructura resiliente. Foto:
+              <a
+                href="https://commons.wikimedia.org/wiki/File:Achuar_community_members_working_cement_(5847200298).jpg"
+                target="_blank"
+                rel="noopener"
+                >SuSanA Secretariat (CC BY 2.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
         </div>
       </section>
 

--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -223,6 +223,70 @@
         </div>
       </section>
 
+      <section class="reto-section" aria-labelledby="galeria-ciudades" data-animate="section">
+        <header data-animate-item>
+          <h2 id="galeria-ciudades">Galería de circularidad urbana</h2>
+          <p>Fotografías que muestran movilidad eléctrica, reutilización de espacios y vida barrial en Kalasatama.</p>
+        </header>
+        <div class="reto-gallery">
+          <figure data-hover-card>
+            <a
+              href="https://commons.wikimedia.org/wiki/File:Cycling_near_S%C3%B6rn%C3%A4isten_rantatie_in_Kalasatama,_Helsinki,_Finland,_2024_April.jpg"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/e/e5/Cycling_near_S%C3%B6rn%C3%A4isten_rantatie_in_Kalasatama%2C_Helsinki%2C_Finland%2C_2024_April.jpg"
+                alt="Personas ciclistas circulan por una vía segregada en Kalasatama"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              La red ciclista climatizada conecta barrios portuarios con el centro. Foto:
+              <a
+                href="https://commons.wikimedia.org/wiki/File:Cycling_near_S%C3%B6rn%C3%A4isten_rantatie_in_Kalasatama,_Helsinki,_Finland,_2024_April.jpg"
+                target="_blank"
+                rel="noopener"
+                >Anne Pietarinen (CC BY 4.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:Bus-charging-Helsinki-2019.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/a/a2/Bus-charging-Helsinki-2019.jpg"
+                alt="Autobús eléctrico cargando en una estación rápida de Helsinki"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Las terminales de carga rápida permiten operar flotas eléctricas en toda la ciudad. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:Bus-charging-Helsinki-2019.jpg" target="_blank" rel="noopener"
+                >User:Mlang.Finn (dominio público) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:Kalasatama_in_Helsinki,_Finland,_2024_August.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/5/54/Kalasatama_in_Helsinki%2C_Finland%2C_2024_August.jpg"
+                alt="Torres residenciales reutilizan estructuras portuarias en Kalasatama"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Reurbanización de muelles integra vivienda mixta y espacios públicos costeros. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:Kalasatama_in_Helsinki,_Finland,_2024_August.jpg" target="_blank" rel="noopener"
+                >Safa Hovinen (CC BY 2.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
       <section class="reto-section" aria-labelledby="cronologia" data-animate="section">
         <header data-animate-item>
           <h2 id="cronologia">Cronología del proceso</h2>

--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -266,6 +266,45 @@
             />
             <figcaption>Vecindarios diseñan microproyectos climáticos con apoyo municipal y cooperativo.</figcaption>
           </figure>
+          <figure data-hover-card>
+            <a
+              href="https://commons.wikimedia.org/wiki/File:Enhance_Climate_Change_Resilience_of_Food_Production_Systems_in_the_Pacific_Communities,_Sapapalii,_16_October,_2014.jpg"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/b/b1/Enhance_Climate_Change_Resilience_of_Food_Production_Systems_in_the_Pacific_Communities%2C_Sapapalii%2C_16_October%2C_2014.jpg"
+                alt="Agricultoras en Samoa plantan cultivos resilientes al clima"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Comunidades agrícolas del Pacífico intercambian prácticas de resiliencia alimentaria. Foto:
+              <a
+                href="https://commons.wikimedia.org/wiki/File:Enhance_Climate_Change_Resilience_of_Food_Production_Systems_in_the_Pacific_Communities,_Sapapalii,_16_October,_2014.jpg"
+                target="_blank"
+                rel="noopener"
+                >US Embassy (dominio público) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:Climate_Smart_Village_Mango_Field_in_Myanmar.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/e/e6/Climate_Smart_Village_Mango_Field_in_Myanmar.jpg"
+                alt="Productores revisan un sistema de riego eficiente en un campo de mangos"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Aldeas climáticamente inteligentes integran riego eficiente y monitoreo comunitario. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:Climate_Smart_Village_Mango_Field_in_Myanmar.jpg" target="_blank" rel="noopener"
+                >IIRR-Myanmar Office (CC BY-SA 4.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
         </div>
       </section>
 

--- a/docs/retos/reto-energia.html
+++ b/docs/retos/reto-energia.html
@@ -209,6 +209,70 @@
         </div>
       </section>
 
+      <section class="reto-section" aria-labelledby="galeria-energia" data-animate="section">
+        <header data-animate-item>
+          <h2 id="galeria-energia">Galería de transición energética justa</h2>
+          <p>Momentos clave de los parques solares, sistemas de almacenamiento y participación comunitaria en Atacama.</p>
+        </header>
+        <div class="reto-gallery">
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:A_village_in_the_desert%3F_(potw2226a).jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/2/26/A_village_in_the_desert%3F_%28potw2226a%29.jpg"
+                alt="Vista aérea de un parque solar rodeado por el desierto de Atacama"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Parques solares cubren antiguos salares con energía limpia para el norte chileno. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:A_village_in_the_desert%3F_(potw2226a).jpg" target="_blank" rel="noopener"
+                >ENEL (CC BY 4.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a href="https://commons.wikimedia.org/wiki/File:BESS_Coya.jpg" target="_blank" rel="noopener">
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/9/9b/BESS_Coya.jpg"
+                alt="Autoridades visitan un sistema de baterías de gran escala en Coya"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Baterías BESS estabilizan la red y priorizan tarifas sociales en horas críticas. Foto:
+              <a href="https://commons.wikimedia.org/wiki/File:BESS_Coya.jpg" target="_blank" rel="noopener"
+                >Dirección de Prensa, Presidencia de la República de Chile (CC BY 3.0 CL) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+          <figure data-hover-card>
+            <a
+              href="https://commons.wikimedia.org/wiki/File:Mandataria_particip%C3%B3_de_la_inauguraci%C3%B3n_de_la_planta_solar_fotovoltaica_%E2%80%9CAmanecer_Solar_CAP%E2%80%9D_(14353750494).jpg"
+              target="_blank"
+              rel="noopener"
+            >
+              <img
+                src="https://upload.wikimedia.org/wikipedia/commons/1/1b/Mandataria_particip%C3%B3_de_la_inauguraci%C3%B3n_de_la_planta_solar_fotovoltaica_%E2%80%9CAmanecer_Solar_CAP%E2%80%9D_%2814353750494%29.jpg"
+                alt="Autoridades y trabajadores celebran la inauguración de una planta solar"
+                loading="lazy"
+                decoding="async"
+              />
+            </a>
+            <figcaption>
+              Inauguraciones públicas refuerzan la gobernanza compartida con cooperativas. Foto:
+              <a
+                href="https://commons.wikimedia.org/wiki/File:Mandataria_particip%C3%B3_de_la_inauguraci%C3%B3n_de_la_planta_solar_fotovoltaica_%E2%80%9CAmanecer_Solar_CAP%E2%80%9D_(14353750494).jpg"
+                target="_blank"
+                rel="noopener"
+                >Gobierno de Chile (CC BY 2.0) vía Wikimedia Commons</a
+              >.
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
       <section class="reto-section" aria-labelledby="mapa" data-animate="section">
         <header data-animate-item>
           <h2 id="mapa">Localización del caso</h2>

--- a/docs/styles/retos.css
+++ b/docs/styles/retos.css
@@ -688,6 +688,13 @@ html[data-theme="dark"] .reto-page {
   border: 1px solid color-mix(in srgb, var(--reto-border) 75%, transparent);
 }
 
+.reto-gallery figure a {
+  display: block;
+  line-height: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
 .reto-gallery img {
   width: 100%;
   height: 100%;
@@ -707,6 +714,12 @@ html[data-theme="dark"] .reto-page {
   background: linear-gradient(180deg, transparent, rgba(15, 23, 42, 0.75));
   color: #fff;
   font-size: 0.95rem;
+}
+
+.reto-gallery figcaption a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.6);
 }
 
 .reto-quote {


### PR DESCRIPTION
## Summary
- extend the biodiversity, agua, aire and clima reto galleries with additional open-license photography and descriptive credits
- add new gallery sections to the ciudades and energía retos that highlight circular mobility and transición energética imagery with proper attributions
- tweak the retos gallery styles so linked figures preserve layout and credit legibility

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68ea9232fe0c8329a127f7722b38c9e8