### PR TITLE
Rearrange global map and reto cards layout

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -790,18 +790,16 @@ body.has-mobile-nav-open {
 /* ===== Mapa y panel ====================================================== */
 #mapa-global {
   position: relative;
-  --map-size: clamp(520px, min(74vw, 85vh), 1040px);
-  --panel-size: clamp(420px, 36vw, 760px);
+  --map-size: clamp(320px, min(90vw, 80vh), 960px);
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   justify-items: center;
   gap: clamp(var(--space-lg), 4vw, var(--space-3xl));
   align-items: center;
-  align-content: center;
+  align-content: start;
   padding: calc(var(--nav-height) + var(--space-2xl)) clamp(2vw, 4vw, 6vw) var(--space-2xl);
-  max-width: min(2040px, 100vw);
+  max-width: min(1280px, 100vw);
   margin-inline: auto;
-  min-height: calc(100vh - var(--nav-height) - var(--space-xl));
 }
 
 #mapa-global .map-container {
@@ -838,29 +836,11 @@ body.has-mobile-nav-open {
   gap: var(--space-lg);
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
-  width: min(100%, var(--panel-size));
+  width: min(100%, var(--map-size));
   max-height: none;
   grid-template-rows: auto auto auto auto;
   align-content: start;
   overflow: visible;
-}
-
-@media (min-width: 960px) {
-  #mapa-global {
-    grid-template-columns: minmax(0, var(--map-size)) minmax(0, var(--panel-size));
-    justify-items: stretch;
-    align-items: stretch;
-  }
-
-  #mapa-global .map-container {
-    justify-self: stretch;
-  }
-
-  #mapa-global .map-panel {
-    width: 100%;
-    height: 100%;
-    align-self: stretch;
-  }
 }
 
 .map-panel [data-retos-list] {
@@ -1491,10 +1471,9 @@ footer small {
   }
 
   #mapa-global {
-    --map-size: clamp(240px, 78vw, 420px);
+    --map-size: clamp(240px, 88vw, 420px);
     grid-template-columns: 1fr;
     justify-items: center;
-    min-height: auto;
     padding: calc(var(--nav-height) + var(--space-xl)) clamp(5vw, 8vw, 10vw) var(--space-xl);
   }
 
@@ -1503,7 +1482,7 @@ footer small {
   }
 
   .map-panel {
-    width: min(100%, 560px);
+    width: min(100%, var(--map-size));
     max-height: none;
   }
 }
@@ -1523,8 +1502,8 @@ footer small {
   }
 
   #mapa-global {
-    grid-template-columns: minmax(360px, var(--map-size)) minmax(360px, 1fr);
-    justify-items: stretch;
+    --map-size: clamp(480px, min(86vw, 80vh), 960px);
+    justify-items: center;
   }
 }
 
@@ -1534,9 +1513,9 @@ footer small {
   }
 
   #mapa-global {
-    --map-size: clamp(640px, min(62vw, 78vh), 1220px);
+    --map-size: clamp(640px, min(70vw, 78vh), 1080px);
     padding: calc(var(--nav-height) + var(--space-2xl)) clamp(3vw, 4vw, 6vw) var(--space-2xl);
-    grid-template-columns: minmax(540px, 1.75fr) minmax(420px, 1fr);
+    justify-items: center;
   }
 
   .hero-content {


### PR DESCRIPTION
## Summary
- stack the global map above the reto cards so the section renders as a single column
- align the map panel width with the map container and refresh responsive breakpoints to keep consistent sizing across screen sizes

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_b_68eacd9eb8608329b33426baa7f2cd15