### PR TITLE
Wrap Unsplash gallery images in picture elements

### DIFF
--- a/docs/retos/reto-agua.html
+++ b/docs/retos/reto-agua.html
@@ -250,12 +250,18 @@
         <div class="reto-gallery">
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/fFRtvdWqyLk" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/fFRtvdWqyLk?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Detalle de tuberías y válvulas pulidas dentro de una planta desalinizadora"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/fFRtvdWqyLk?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/fFRtvdWqyLk?auto=format&fit=crop&w=1400&q=80"
+                  alt="Detalle de tuberías y válvulas pulidas dentro de una planta desalinizadora"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Ingeniería de ósmosis inversa con sensores integrados para optimizar el caudal. Foto:
@@ -265,12 +271,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/Rdxjg7UqF08" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/Rdxjg7UqF08?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Vista aérea de depósitos circulares de agua rodeados por pistas en una zona árida"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/Rdxjg7UqF08?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/Rdxjg7UqF08?auto=format&fit=crop&w=1400&q=80"
+                  alt="Vista aérea de depósitos circulares de agua rodeados por pistas en una zona árida"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Reservorios modulares almacenan agua desalada cerca de los campos agrícolas. Foto:
@@ -280,12 +292,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/hHmhQ1jXfMc" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/hHmhQ1jXfMc?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Filas de tanques presurizados azules alineados en una planta de tratamiento"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/hHmhQ1jXfMc?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/hHmhQ1jXfMc?auto=format&fit=crop&w=1400&q=80"
+                  alt="Filas de tanques presurizados azules alineados en una planta de tratamiento"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Tanques presurizados estabilizan la presión antes de distribuir agua potable. Foto:


### PR DESCRIPTION
## Summary
- wrap each Unsplash gallery image in a `<picture>` element with a WebP source
- preserve existing attributes while adding JPEG fallbacks without the `fm=webp` parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ead1bddfa083299c5bf569731b8ee0