### PR TITLE
Refine map popup styling

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -98,7 +98,7 @@ a:focus-visible {
   --shadow-md: 0 16px 30px rgba(15, 23, 42, 0.28);
   --shadow-lg: 0 24px 50px rgba(14, 165, 233, 0.35);
 
-  --map-popup-width: clamp(360px, 56vw, 520px);
+  --map-popup-width: clamp(280px, 44vw, 360px);
 
   --z-base: 0;
   --z-content: 10;
@@ -961,12 +961,12 @@ body.has-mobile-nav-open {
 }
 
 .leaflet-popup-content {
-  font-size: clamp(1rem, 1.8vw, 1.1rem);
-  line-height: 1.6;
+  font-size: clamp(0.95rem, 1.8vw, 1.05rem);
+  line-height: 1.55;
   width: 100%;
   max-width: var(--map-popup-width);
   margin: 0;
-  padding: clamp(var(--space-md), 2.4vw, var(--space-xl));
+  padding: clamp(var(--space-sm), 2vw, var(--space-lg));
   box-sizing: border-box;
 }
 
@@ -976,29 +976,45 @@ body.has-mobile-nav-open {
 }
 
 .leaflet-popup-content-wrapper {
-  border-radius: clamp(1.4rem, 4vw, 2.2rem) clamp(1.4rem, 4vw, 2.2rem) var(--radius-lg)
-    var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--color-border) 45%, transparent);
-  box-shadow: var(--shadow-lg);
-  background: color-mix(in srgb, var(--color-elevated) 75%, var(--color-surface));
-  backdrop-filter: blur(14px);
+  position: relative;
+  border-radius: clamp(1.1rem, 3.4vw, 1.8rem);
+  border: 1px solid color-mix(in srgb, var(--color-border) 35%, transparent);
+  box-shadow: var(--shadow-md);
+  background: color-mix(in srgb, var(--color-elevated) 60%, var(--color-surface));
+  backdrop-filter: blur(10px);
   inline-size: var(--map-popup-width);
   min-inline-size: var(--map-popup-width);
   max-inline-size: min(var(--map-popup-width), calc(100vw - var(--space-xl)));
   width: var(--map-popup-width);
+  overflow: hidden;
+}
+
+.leaflet-popup-content-wrapper::before {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  height: 6px;
+  background: linear-gradient(
+    120deg,
+    color-mix(in srgb, var(--color-accent) 85%, transparent) 0%,
+    color-mix(in srgb, var(--color-accent-strong) 70%, transparent) 100%
+  );
 }
 
 .map-popup {
   display: grid;
-  gap: clamp(var(--space-sm), 1.4vw, var(--space-md));
+  gap: clamp(var(--space-xs), 1.1vw, var(--space-sm));
   width: 100%;
   max-width: var(--map-popup-width);
-  justify-items: center;
+  justify-items: stretch;
+  text-align: left;
   animation: map-popup-rise var(--transition-long);
 }
 
 .map-popup header {
   width: 100%;
+  display: grid;
 }
 
 .map-popup header h3 {
@@ -1006,11 +1022,11 @@ body.has-mobile-nav-open {
   align-items: center;
   gap: var(--space-2xs);
   margin: 0;
-  padding: clamp(var(--space-2xs), 1vw, var(--space-sm))
-    clamp(var(--space-sm), 1.8vw, var(--space-md));
-  background: color-mix(in srgb, var(--color-surface-alt) 45%, transparent);
-  border-radius: var(--radius-md);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-border) 35%, transparent);
+  padding: clamp(var(--space-2xs), 1vw, var(--space-xs))
+    clamp(var(--space-sm), 1.6vw, var(--space-md));
+  background: color-mix(in srgb, var(--color-surface-alt) 60%, transparent);
+  border-radius: var(--radius-sm);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-border) 30%, transparent);
   font-family: var(--font-heading);
   letter-spacing: 0.01em;
 }
@@ -1020,17 +1036,22 @@ body.has-mobile-nav-open {
   width: 100%;
 }
 
+.map-popup p {
+  margin-block: 0;
+  color: color-mix(in srgb, var(--color-text) 85%, var(--color-muted) 15%);
+}
+
 .map-popup__media {
   display: grid;
   place-items: center;
-  inline-size: clamp(200px, 46%, 260px);
-  padding: clamp(var(--space-xs), 1.5vw, var(--space-md));
-  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-  border-radius: var(--radius-lg);
+  inline-size: min(100%, 220px);
+  padding: clamp(var(--space-2xs), 1.4vw, var(--space-sm));
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  border-radius: var(--radius-md);
   position: relative;
   overflow: hidden;
   justify-self: center;
-  margin-inline: auto;
+  margin-block: clamp(var(--space-2xs), 1vw, var(--space-sm));
 }
 
 .map-popup__media img {
@@ -1048,10 +1069,10 @@ body.has-mobile-nav-open {
 }
 
 .map-popup__media img {
-  width: min(100%, 240px);
+  width: min(100%, 200px);
   aspect-ratio: 4 / 3;
   object-fit: cover;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   box-shadow: var(--shadow-sm);
   transition: transform var(--transition-long), box-shadow var(--transition-long);
 }
@@ -1067,14 +1088,16 @@ body.has-mobile-nav-open {
   align-items: center;
   justify-content: center;
   gap: var(--space-2xs);
-  padding: var(--space-xs) clamp(var(--space-md), 4vw, var(--space-xl));
-  min-width: clamp(10rem, 60%, 14rem);
+  padding: clamp(var(--space-xs), 1.4vw, var(--space-sm))
+    clamp(var(--space-md), 4vw, var(--space-lg));
+  min-width: unset;
+  width: min(100%, 18rem);
   font-weight: 600;
   color: var(--color-accent-strong);
-  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-accent-strong) 45%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 24%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-strong) 40%, transparent);
   border-radius: var(--radius-pill);
-  box-shadow: 0 8px 24px rgba(14, 165, 233, 0.3);
+  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.22);
   text-decoration: none;
   position: relative;
   overflow: hidden;
@@ -1110,8 +1133,8 @@ body.has-mobile-nav-open {
   .leaflet-popup-content,
   .map-popup,
   .leaflet-popup-content-wrapper {
-    width: min(88vw, 420px);
-    inline-size: min(88vw, 420px);
+    width: min(90vw, 340px);
+    inline-size: min(90vw, 340px);
     min-inline-size: 0;
     max-inline-size: none;
     max-width: none;


### PR DESCRIPTION
## Summary
- reduce the Leaflet popup width to feel lighter on desktop and mobile
- refresh popup layout with left alignment, accent header bar, and softer shadows
- tighten media and button styles for a cleaner call to action

## Testing
- not run (visual change only)


------
https://chatgpt.com/codex/tasks/task_b_68ead26d43bc8329a8a718d519bd3315