### PR TITLE
Wrap Unsplash gallery images with picture fallbacks

### DIFF
--- a/docs/retos/reto-aire.html
+++ b/docs/retos/reto-aire.html
@@ -242,12 +242,18 @@
         <div class="reto-gallery">
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/TvtsNBlSahc" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/TvtsNBlSahc?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Mano sosteniendo un sensor portátil de color blanco y amarillo con pantalla encendida"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/TvtsNBlSahc?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/TvtsNBlSahc?auto=format&fit=crop&w=1400&q=80"
+                  alt="Mano sosteniendo un sensor portátil de color blanco y amarillo con pantalla encendida"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Redes vecinales auditan emisiones con medidores móviles de bajo costo. Foto:
@@ -257,12 +263,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/OtW3XS4Yjd0" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/OtW3XS4Yjd0?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Panel solar vertical instalado en la fachada de un edificio urbano"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/OtW3XS4Yjd0?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/OtW3XS4Yjd0?auto=format&fit=crop&w=1400&q=80"
+                  alt="Panel solar vertical instalado en la fachada de un edificio urbano"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Sensores urbanos se alimentan con energía solar para reportar en tiempo real. Foto:
@@ -272,12 +284,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/0vmMg1r7FRU" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/0vmMg1r7FRU?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Antena roja equipada con sensores desplegada en un parque urbano"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/0vmMg1r7FRU?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/0vmMg1r7FRU?auto=format&fit=crop&w=1400&q=80"
+                  alt="Antena roja equipada con sensores desplegada en un parque urbano"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Redes LoRaWAN permiten conectar estaciones ciudadanas en áreas verdes. Foto:
@@ -287,12 +305,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/pgSE5_Eu8m4" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/pgSE5_Eu8m4?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Mural con mensaje Stop Air Pollution pintado en rojo sobre pared amarilla"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/pgSE5_Eu8m4?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/pgSE5_Eu8m4?auto=format&fit=crop&w=1400&q=80"
+                  alt="Mural con mensaje Stop Air Pollution pintado en rojo sobre pared amarilla"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Campañas barriales visibilizan datos de contaminación para exigir zonas de bajas emisiones. Foto:


### PR DESCRIPTION
## Summary
- wrap each Unsplash image in the gallery with a `<picture>` element that serves WebP sources
- add fallback `<img>` tags without the WebP format parameter to preserve compatibility with legacy browsers

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68ead39551b48329a746fbaf76e81e63