### PR TITLE
Add picture fallbacks for Unsplash gallery images

### DIFF
--- a/docs/retos/reto-biodiversidad.html
+++ b/docs/retos/reto-biodiversidad.html
@@ -241,12 +241,18 @@
         <div class="reto-gallery">
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/nDIiQIcLHrk" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/nDIiQIcLHrk?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Canales de agua cristalina bordeados por manglares y árboles tropicales"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/nDIiQIcLHrk?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/nDIiQIcLHrk?auto=format&fit=crop&w=1400&q=80"
+                  alt="Canales de agua cristalina bordeados por manglares y árboles tropicales"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Reservas indígenas protegen corredores acuáticos que sostienen especies clave. Foto:
@@ -256,12 +262,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/yu65E0RSwSM" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/yu65E0RSwSM?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Letrero comunitario clavado sobre una laguna protegida"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/yu65E0RSwSM?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/yu65E0RSwSM?auto=format&fit=crop&w=1400&q=80"
+                  alt="Letrero comunitario clavado sobre una laguna protegida"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Señalética local informa reglas de pesca responsable en territorios co-manejados. Foto:
@@ -271,12 +283,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/9KVAGieMBng" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/9KVAGieMBng?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Río tranquilo serpenteando entre árboles nativos densos"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/9KVAGieMBng?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/9KVAGieMBng?auto=format&fit=crop&w=1400&q=80"
+                  alt="Río tranquilo serpenteando entre árboles nativos densos"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Restauración ribereña reduce la erosión y devuelve hábitats a las comunidades forestales. Foto:
@@ -286,12 +304,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/_qUsMvdxX3s" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/_qUsMvdxX3s?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Personas navegando en kayak por un túnel verde de manglares"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/_qUsMvdxX3s?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/_qUsMvdxX3s?auto=format&fit=crop&w=1400&q=80"
+                  alt="Personas navegando en kayak por un túnel verde de manglares"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Turismo comunitario financia guardabosques y monitoreo participativo. Foto:


### PR DESCRIPTION
## Summary
- wrap each Unsplash gallery image in a picture element
- provide a WebP source and JPEG fallback while preserving accessibility attributes

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_b_68ead40f8c748329a2a8af525b5963c8