### PR TITLE
Wrap Unsplash gallery images with WebP sources

### DIFF
--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -286,12 +286,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/3lphfshJdkg" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/3lphfshJdkg?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Bicicletas urbanas estacionadas junto a comercios y furgonetas"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/3lphfshJdkg?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/3lphfshJdkg?auto=format&fit=crop&w=1400&q=80"
+                  alt="Bicicletas urbanas estacionadas junto a comercios y furgonetas"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Comercios de barrio integran logística en bici para reducir emisiones de reparto. Foto:
@@ -301,12 +307,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/4nXYEUjlyLU" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/4nXYEUjlyLU?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Personas circulan en bicicletas eléctricas por una avenida arbolada"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/4nXYEUjlyLU?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/4nXYEUjlyLU?auto=format&fit=crop&w=1400&q=80"
+                  alt="Personas circulan en bicicletas eléctricas por una avenida arbolada"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               La micromovilidad compartida facilita traslados de última milla en Kalasatama. Foto:
@@ -316,12 +328,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/LhqlMNtGxXI" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/LhqlMNtGxXI?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Patinete eléctrico apoyado en un mural colorido en la ciudad"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/LhqlMNtGxXI?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/LhqlMNtGxXI?auto=format&fit=crop&w=1400&q=80"
+                  alt="Patinete eléctrico apoyado en un mural colorido en la ciudad"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Laboratorios ciudadanos prueban servicios compartidos y arte urbano para humanizar calles. Foto:


### PR DESCRIPTION
## Summary
- wrap each Unsplash photo in the reto-ciudades gallery with a `<picture>` element that offers a WebP source and JPEG fallback
- preserve existing accessibility and loading attributes on the fallback `<img>` tags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ead52e7260832999ccc051064c9948