### PR TITLE
Update timeline markup for reto ciudades page

### DIFF
--- a/docs/retos/reto-ciudades.html
+++ b/docs/retos/reto-ciudades.html
@@ -355,25 +355,20 @@
           <h2 id="cronologia">Cronología del proceso</h2>
           <p>Hitos clave para consolidar la circularidad urbana en Helsinki.</p>
         </header>
-        <ol class="reto-timeline" data-animate-item>
-          <li>
-            <strong>2015</strong>
+        <ol class="timeline" data-animate-item>
+          <li class="timeline-item" data-year="2015">
             <span>Se lanza la visión Kalasatama Smart City con participación ciudadana y pilotos de energía inteligente.</span>
           </li>
-          <li>
-            <strong>2018</strong>
+          <li class="timeline-item" data-year="2018">
             <span>La ciudad adopta la hoja de ruta "Helsinki Circular Economy" con objetivos de reutilización del 50&nbsp;% de materiales.</span>
           </li>
-          <li>
-            <strong>2020</strong>
+          <li class="timeline-item" data-year="2020">
             <span>Inicio del programa de movilidad eléctrica compartida y estaciones de carga rápida en todos los distritos.</span>
           </li>
-          <li>
-            <strong>2022</strong>
+          <li class="timeline-item" data-year="2022">
             <span>Creación del banco digital de materiales de construcción y obligatoriedad en licitaciones públicas.</span>
           </li>
-          <li>
-            <strong>2024</strong>
+          <li class="timeline-item" data-year="2024">
             <span>Expansión del modelo circular a Pasila y Malmi con cooperativas de reutilización y redes de energía local.</span>
           </li>
         </ol>


### PR DESCRIPTION
## Summary
- switch the reto ciudades chronology list to use the shared `.timeline` structure
- move years into `data-year` attributes and apply `timeline-item` classes for consistent styling

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_b_68ead5b84d608329b2f1af53e21f0e83