### PR TITLE
Wrap Unsplash gallery images in picture elements

### DIFF
--- a/docs/retos/reto-clima.html
+++ b/docs/retos/reto-clima.html
@@ -241,12 +241,18 @@
         <div class="reto-gallery">
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/bXXcFM5od0U" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/bXXcFM5od0U?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Palmera aislada en medio de un paisaje árido con dunas"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/bXXcFM5od0U?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/bXXcFM5od0U?auto=format&fit=crop&w=1400&q=80"
+                  alt="Palmera aislada en medio de un paisaje árido con dunas"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Oasis urbanos capturan escorrentías y crean microclimas refrescantes. Foto:
@@ -256,12 +262,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/KZu2HFw5Bq0" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/KZu2HFw5Bq0?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Vista aérea de un pueblo rodeado de bosques y lagunas"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/KZu2HFw5Bq0?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/KZu2HFw5Bq0?auto=format&fit=crop&w=1400&q=80"
+                  alt="Vista aérea de un pueblo rodeado de bosques y lagunas"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Planes de adaptación integran mosaicos de naturaleza y barrios compactos. Foto:
@@ -271,12 +283,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/WkFa1bhkgOo" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/WkFa1bhkgOo?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Mujer navega en bote por una calle inundada"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/WkFa1bhkgOo?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/WkFa1bhkgOo?auto=format&fit=crop&w=1400&q=80"
+                  alt="Mujer navega en bote por una calle inundada"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Sistemas de alerta y evacuación priorizan a comunidades en riesgo de inundación. Foto:
@@ -309,12 +327,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/4OGLIWjuxO0" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/4OGLIWjuxO0?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Cartel amarillo con la frase All Climate Matters sostenido por activistas"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/4OGLIWjuxO0?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/4OGLIWjuxO0?auto=format&fit=crop&w=1400&q=80"
+                  alt="Cartel amarillo con la frase All Climate Matters sostenido por activistas"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Movilizaciones ciudadanas impulsan presupuestos climáticos participativos. Foto:


### PR DESCRIPTION
## Summary
- wrap each Unsplash gallery image in a picture element with a WebP source
- add JPEG/PNG fallbacks by removing the fm=webp parameter while preserving existing attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ead6b60b248329af2834ef0414dfe8