### PR TITLE
Wrap Unsplash images with picture fallbacks

### DIFF
--- a/docs/retos/reto-energia.html
+++ b/docs/retos/reto-energia.html
@@ -272,12 +272,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/Hl75CiAINfI" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/Hl75CiAINfI?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Panel solar con aerogeneradores al fondo iluminados por el amanecer"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/Hl75CiAINfI?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/Hl75CiAINfI?auto=format&fit=crop&w=1400&q=80"
+                  alt="Panel solar con aerogeneradores al fondo iluminados por el amanecer"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Híbridos eólico-solares permiten entregar energía continua a cooperativas mineras. Foto:
@@ -287,12 +293,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/XVwYGihplmY" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/XVwYGihplmY?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Techo residencial equipado con paneles solares y tanque de agua"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/XVwYGihplmY?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/XVwYGihplmY?auto=format&fit=crop&w=1400&q=80"
+                  alt="Techo residencial equipado con paneles solares y tanque de agua"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Programas de techos solares incluyen almacenamiento doméstico para comunidades pampinas. Foto:
@@ -302,12 +314,18 @@
           </figure>
           <figure data-hover-card>
             <a href="https://unsplash.com/photos/6gR302nQq0g" target="_blank" rel="noopener">
-              <img
-                src="https://images.unsplash.com/6gR302nQq0g?auto=format&fit=crop&w=1400&q=80&fm=webp"
-                alt="Gran campo de paneles solares en medio de un llano árido"
-                loading="lazy"
-                decoding="async"
-              />
+              <picture>
+                <source
+                  type="image/webp"
+                  srcset="https://images.unsplash.com/6gR302nQq0g?auto=format&fit=crop&w=1400&q=80&fm=webp"
+                />
+                <img
+                  src="https://images.unsplash.com/6gR302nQq0g?auto=format&fit=crop&w=1400&q=80"
+                  alt="Gran campo de paneles solares en medio de un llano árido"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </picture>
             </a>
             <figcaption>
               Cooperativas energéticas gestionan parques compartidos que alimentan microrredes locales. Foto:


### PR DESCRIPTION
## Summary
- wrap each Unsplash photo in the energy challenge page with a picture element
- keep the WebP source while adding non-WebP image fallbacks to improve compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ead836e02c8329b2eccadda91790d0